### PR TITLE
build on CentOS 7/GCC 5.2 with -Wall,extra,pedantic

### DIFF
--- a/format.cc
+++ b/format.cc
@@ -122,7 +122,7 @@ namespace
 	}
 
 	template <typename T>
-	void write_signed(formatxx::format_writer& out, T value, formatxx::format_spec const& spec)
+	void write_signed(formatxx::format_writer& out, T value, formatxx::format_spec const&)
 	{
 		char buffer[kIntBufferSize];
 		out.write(gen_signed_decimal(buffer, value));

--- a/format.h
+++ b/format.h
@@ -38,7 +38,9 @@
 
 namespace std
 {
+#ifndef __GNUC__
 	template <typename, typename, typename> class basic_string;
+#endif
 	template <typename> class allocator;
 }
 

--- a/format.h
+++ b/format.h
@@ -36,13 +36,7 @@
 #include <cstring>
 #include <memory>
 
-namespace std
-{
-#ifndef __GNUC__
-	template <typename, typename, typename> class basic_string;
-#endif
-	template <typename> class allocator;
-}
+#include "format_std.h"
 
 namespace formatxx
 {

--- a/format_std.h
+++ b/format_std.h
@@ -1,0 +1,38 @@
+// formatxx - C++ string formatting library.
+//
+// This is free and unencumbered software released into the public domain.
+// 
+// Anyone is free to copy, modify, publish, use, compile, sell, or
+// distribute this software, either in source code form or as a compiled
+// binary, for any purpose, commercial or non - commercial, and by any
+// means.
+// 
+// In jurisdictions that recognize copyright laws, the author or authors
+// of this software dedicate any and all copyright interest in the
+// software to the public domain. We make this dedication for the benefit
+// of the public at large and to the detriment of our heirs and
+// successors. We intend this dedication to be an overt act of
+// relinquishment in perpetuity of all present and future rights to this
+// software under copyright law.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+// 
+// For more information, please refer to <http://unlicense.org/>
+//
+// Authors:
+//   Sean Middleditch <sean@middleditch.us>
+//   Wesley Griffin <wesley.griffin@nist.gov>
+
+#if !defined(_guard_FORMATXX_STD_H)
+#define _guard_FORMATXX_STD_H
+#pragma once
+
+#include <string>
+
+#endif // !defined(_guard_FORMATXX_STD_H)


### PR DESCRIPTION
With GCC 5.2, <memory> includes <iosfwd> which includes <stringfwd> which declares std::basic_string. So I put a guard around the std::basic_string declaration in format.h

Thanks,
Wes
