### PR TITLE
Format spec cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ set(FORMATXX_PRIVATE_HEADERS
     include/formatxx/_detail/format_traits.h
     include/formatxx/_detail/format_util.h
     include/formatxx/_detail/parse_format.h
+    include/formatxx/_detail/parse_printf.h
     include/formatxx/_detail/parse_unsigned.h
     include/formatxx/_detail/printf_impl.h
     include/formatxx/_detail/write_float.h

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(litexx EXCLUDE_FROM_ALL)
 
-if(FORMATXX_BUILD_TESTS)
+if(FORMATXX_BUILD_TESTS AND NOT TARGET doctest)
     set(DOCTEST_WITH_TESTS OFF CACHE BOOL "enable doctest tests")
+    set(DOCTEST_WITH_MAIN_IN_STATIC_LIB OFF CACHE BOOL "enable doctest static library")
     add_subdirectory(doctest EXCLUDE_FROM_ALL)
 endif()

--- a/include/formatxx/_detail/format_arg.h
+++ b/include/formatxx/_detail/format_arg.h
@@ -66,13 +66,13 @@ enum class formatxx::_detail::format_arg_type {
 template <typename CharT>
 class formatxx::_detail::basic_format_arg {
 public:
-    using thunk_type = result_code(FORMATXX_API*)(basic_format_writer<CharT>&, void const*, basic_format_spec<CharT>);
+    using thunk_type = result_code(FORMATXX_API*)(basic_format_writer<CharT>&, void const*, basic_format_options<CharT>);
 
     constexpr basic_format_arg() noexcept = default;
     constexpr basic_format_arg(_detail::format_arg_type type, void const* value) noexcept : _type(type), _value(value) {}
     constexpr basic_format_arg(thunk_type thunk, void const* value) noexcept : _type(_detail::format_arg_type::custom), _thunk(thunk), _value(value) {}
 
-    FORMATXX_PUBLIC result_code FORMATXX_API format_into(basic_format_writer<CharT>& output, basic_format_spec<CharT> const& spec) const;
+    FORMATXX_PUBLIC result_code FORMATXX_API format_into(basic_format_writer<CharT>& output, basic_format_options<CharT> const& options) const;
 
 private:
     _detail::format_arg_type _type = _detail::format_arg_type::unknown;
@@ -91,8 +91,8 @@ public:
     constexpr basic_format_arg_list() noexcept = default;
     constexpr basic_format_arg_list(std::initializer_list<format_arg_type> args) noexcept : _args(args.begin()), _count(args.size()) {}
 
-    constexpr result_code format_arg(basic_format_writer<CharT>& output, size_type index, basic_format_spec<CharT> const& spec) const {
-        return index < _count ? _args[index].format_into(output, spec) : result_code::out_of_range;
+    constexpr result_code format_arg(basic_format_writer<CharT>& output, size_type index, basic_format_options<CharT> const& options) const {
+        return index < _count ? _args[index].format_into(output, options) : result_code::out_of_range;
     }
 
 private:
@@ -110,7 +110,7 @@ namespace formatxx::_detail {
     template <typename C, typename T, typename V = void>
     struct has_format_value { static constexpr bool value = false; };
     template <typename C, typename T>
-    struct has_format_value<C, T, std::void_t<decltype(format_value(std::declval<basic_format_writer<C>&>(), std::declval<T>(), std::declval<basic_format_spec<C>>()))>> {
+    struct has_format_value<C, T, std::void_t<decltype(format_value(std::declval<basic_format_writer<C>&>(), std::declval<T>(), std::declval<basic_format_options<C>>()))>> {
         static constexpr bool value = true;
     };
 
@@ -141,8 +141,8 @@ namespace formatxx::_detail {
 #undef FORMTAXX_TYPE
 
     template <typename CharT, typename T>
-    result_code FORMATXX_API format_value_thunk(basic_format_writer<CharT>& out, void const* ptr, basic_format_spec<CharT> spec) {
-        format_value(out, *static_cast<T const*>(ptr), spec);
+    result_code FORMATXX_API format_value_thunk(basic_format_writer<CharT>& out, void const* ptr, basic_format_options<CharT> options) {
+        format_value(out, *static_cast<T const*>(ptr), options);
         return result_code::success;
     }
 

--- a/include/formatxx/_detail/format_arg.h
+++ b/include/formatxx/_detail/format_arg.h
@@ -72,7 +72,7 @@ public:
     constexpr basic_format_arg(_detail::format_arg_type type, void const* value) noexcept : _type(type), _value(value) {}
     constexpr basic_format_arg(thunk_type thunk, void const* value) noexcept : _type(_detail::format_arg_type::custom), _thunk(thunk), _value(value) {}
 
-    FORMATXX_PUBLIC result_code FORMATXX_API format_into(basic_format_writer<CharT>& output, basic_format_spec<CharT> spec) const;
+    FORMATXX_PUBLIC result_code FORMATXX_API format_into(basic_format_writer<CharT>& output, basic_format_spec<CharT> const& spec) const;
 
 private:
     _detail::format_arg_type _type = _detail::format_arg_type::unknown;
@@ -91,7 +91,7 @@ public:
     constexpr basic_format_arg_list() noexcept = default;
     constexpr basic_format_arg_list(std::initializer_list<format_arg_type> args) noexcept : _args(args.begin()), _count(args.size()) {}
 
-    constexpr result_code format_arg(basic_format_writer<CharT>& output, size_type index, basic_format_spec<CharT> spec) const {
+    constexpr result_code format_arg(basic_format_writer<CharT>& output, size_type index, basic_format_spec<CharT> const& spec) const {
         return index < _count ? _args[index].format_into(output, spec) : result_code::out_of_range;
     }
 

--- a/include/formatxx/_detail/format_arg.h
+++ b/include/formatxx/_detail/format_arg.h
@@ -66,13 +66,13 @@ enum class formatxx::_detail::format_arg_type {
 template <typename CharT>
 class formatxx::_detail::basic_format_arg {
 public:
-    using thunk_type = result_code(FORMATXX_API*)(basic_format_writer<CharT>&, void const*, basic_string_view<CharT>);
+    using thunk_type = result_code(FORMATXX_API*)(basic_format_writer<CharT>&, void const*, basic_format_spec<CharT>);
 
     constexpr basic_format_arg() noexcept = default;
     constexpr basic_format_arg(_detail::format_arg_type type, void const* value) noexcept : _type(type), _value(value) {}
     constexpr basic_format_arg(thunk_type thunk, void const* value) noexcept : _type(_detail::format_arg_type::custom), _thunk(thunk), _value(value) {}
 
-    FORMATXX_PUBLIC result_code FORMATXX_API format_into(basic_format_writer<CharT>& output, basic_string_view<CharT> spec) const;
+    FORMATXX_PUBLIC result_code FORMATXX_API format_into(basic_format_writer<CharT>& output, basic_format_spec<CharT> spec) const;
 
 private:
     _detail::format_arg_type _type = _detail::format_arg_type::unknown;
@@ -91,7 +91,7 @@ public:
     constexpr basic_format_arg_list() noexcept = default;
     constexpr basic_format_arg_list(std::initializer_list<format_arg_type> args) noexcept : _args(args.begin()), _count(args.size()) {}
 
-    constexpr result_code format_arg(basic_format_writer<CharT>& output, size_type index, basic_string_view<CharT> spec) const {
+    constexpr result_code format_arg(basic_format_writer<CharT>& output, size_type index, basic_format_spec<CharT> spec) const {
         return index < _count ? _args[index].format_into(output, spec) : result_code::out_of_range;
     }
 
@@ -110,7 +110,7 @@ namespace formatxx::_detail {
     template <typename C, typename T, typename V = void>
     struct has_format_value { static constexpr bool value = false; };
     template <typename C, typename T>
-    struct has_format_value<C, T, std::void_t<decltype(format_value(std::declval<basic_format_writer<C>&>(), std::declval<T>(), std::declval<basic_string_view<C>>()))>> {
+    struct has_format_value<C, T, std::void_t<decltype(format_value(std::declval<basic_format_writer<C>&>(), std::declval<T>(), std::declval<basic_format_spec<C>>()))>> {
         static constexpr bool value = true;
     };
 
@@ -141,7 +141,7 @@ namespace formatxx::_detail {
 #undef FORMTAXX_TYPE
 
     template <typename CharT, typename T>
-    result_code FORMATXX_API format_value_thunk(basic_format_writer<CharT>& out, void const* ptr, basic_string_view<CharT> spec) {
+    result_code FORMATXX_API format_value_thunk(basic_format_writer<CharT>& out, void const* ptr, basic_format_spec<CharT> spec) {
         format_value(out, *static_cast<T const*>(ptr), spec);
         return result_code::success;
     }

--- a/include/formatxx/_detail/format_arg_impl.h
+++ b/include/formatxx/_detail/format_arg_impl.h
@@ -36,67 +36,67 @@
 #include <cinttypes>
 
 template <typename CharT>
-formatxx::result_code FORMATXX_API formatxx::_detail::basic_format_arg<CharT>::format_into(basic_format_writer<CharT>& output, basic_format_spec<CharT> const& spec) const {
+formatxx::result_code FORMATXX_API formatxx::_detail::basic_format_arg<CharT>::format_into(basic_format_writer<CharT>& output, basic_format_options<CharT> const& options) const {
     switch (_type) {
     case _detail::format_arg_type::char_t:
-        _detail::write_char(output, *static_cast<char const*>(_value), spec);
+        _detail::write_char(output, *static_cast<char const*>(_value), options);
         return result_code::success;
     case _detail::format_arg_type::wchar:
-        _detail::write_char(output, *static_cast<wchar_t const*>(_value), spec);
+        _detail::write_char(output, *static_cast<wchar_t const*>(_value), options);
         return result_code::success;
     case _detail::format_arg_type::signed_char:
-        _detail::write_integer(output, *static_cast<signed char const*>(_value), spec);
+        _detail::write_integer(output, *static_cast<signed char const*>(_value), options);
         return result_code::success;
     case _detail::format_arg_type::unsigned_char:
-        _detail::write_integer(output, *static_cast<unsigned char const*>(_value), spec);
+        _detail::write_integer(output, *static_cast<unsigned char const*>(_value), options);
         return result_code::success;
     case _detail::format_arg_type::signed_int:
-        _detail::write_integer(output, *static_cast<signed int const*>(_value), spec);
+        _detail::write_integer(output, *static_cast<signed int const*>(_value), options);
         return result_code::success;
     case _detail::format_arg_type::unsigned_int:
-        _detail::write_integer(output, *static_cast<unsigned int const*>(_value), spec);
+        _detail::write_integer(output, *static_cast<unsigned int const*>(_value), options);
         return result_code::success;
     case _detail::format_arg_type::signed_short_int:
-		_detail::write_integer(output, *static_cast<signed short const*>(_value), spec);
+		_detail::write_integer(output, *static_cast<signed short const*>(_value), options);
 		return result_code::success;
     case _detail::format_arg_type::unsigned_short_int:
-		_detail::write_integer(output, *static_cast<unsigned short const*>(_value), spec);
+		_detail::write_integer(output, *static_cast<unsigned short const*>(_value), options);
 		return result_code::success;
     case _detail::format_arg_type::signed_long_int:
-		_detail::write_integer(output, *static_cast<signed long const*>(_value), spec);
+		_detail::write_integer(output, *static_cast<signed long const*>(_value), options);
 		return result_code::success;
     case _detail::format_arg_type::unsigned_long_int:
-		_detail::write_integer(output, *static_cast<unsigned long const*>(_value), spec);
+		_detail::write_integer(output, *static_cast<unsigned long const*>(_value), options);
 		return result_code::success;
     case _detail::format_arg_type::signed_long_long_int:
-		_detail::write_integer(output, *static_cast<signed long long const*>(_value), spec);
+		_detail::write_integer(output, *static_cast<signed long long const*>(_value), options);
 		return result_code::success;
     case _detail::format_arg_type::unsigned_long_long_int:
-		_detail::write_integer(output, *static_cast<unsigned long long const*>(_value), spec);
+		_detail::write_integer(output, *static_cast<unsigned long long const*>(_value), options);
 		return result_code::success;
     case _detail::format_arg_type::single_float:
-		_detail::write_float(output, *static_cast<float const*>(_value), spec);
+		_detail::write_float(output, *static_cast<float const*>(_value), options);
 		return result_code::success;
     case _detail::format_arg_type::double_float:
-		_detail::write_float(output, *static_cast<double const*>(_value), spec);
+		_detail::write_float(output, *static_cast<double const*>(_value), options);
 		return result_code::success;
     case _detail::format_arg_type::boolean:
-		_detail::write_string(output, *static_cast<bool const*>(_value) ? _detail::FormatTraits<CharT>::sTrue : _detail::FormatTraits<CharT>::sFalse, spec);
+		_detail::write_string(output, *static_cast<bool const*>(_value) ? _detail::FormatTraits<CharT>::sTrue : _detail::FormatTraits<CharT>::sFalse, options);
 		return result_code::success;
     case _detail::format_arg_type::char_string:
-		_detail::write_string(output, string_view(*static_cast<char const* const*>(_value)), spec);
+		_detail::write_string(output, string_view(*static_cast<char const* const*>(_value)), options);
 		return result_code::success;
     case _detail::format_arg_type::wchar_string:
-		_detail::write_string(output, wstring_view(*static_cast<wchar_t const* const*>(_value)), spec);
+		_detail::write_string(output, wstring_view(*static_cast<wchar_t const* const*>(_value)), options);
 		return result_code::success;
     case _detail::format_arg_type::null_pointer:
-		_detail::write_string(output, _detail::FormatTraits<CharT>::sNullptr, spec);
+		_detail::write_string(output, _detail::FormatTraits<CharT>::sNullptr, options);
 		return result_code::success;
     case _detail::format_arg_type::void_pointer:
-		_detail::write_integer(output, reinterpret_cast<std::uintptr_t>(*static_cast<void const* const*>(_value)), spec);
+		_detail::write_integer(output, reinterpret_cast<std::uintptr_t>(*static_cast<void const* const*>(_value)), options);
 		return result_code::success;
     case _detail::format_arg_type::custom:
-        return _thunk(output, _value, spec);
+        return _thunk(output, _value, options);
     default:
         return result_code::success;
     }

--- a/include/formatxx/_detail/format_arg_impl.h
+++ b/include/formatxx/_detail/format_arg_impl.h
@@ -36,7 +36,7 @@
 #include <cinttypes>
 
 template <typename CharT>
-formatxx::result_code FORMATXX_API formatxx::_detail::basic_format_arg<CharT>::format_into(basic_format_writer<CharT>& output, basic_format_spec<CharT> spec) const {
+formatxx::result_code FORMATXX_API formatxx::_detail::basic_format_arg<CharT>::format_into(basic_format_writer<CharT>& output, basic_format_spec<CharT> const& spec) const {
     switch (_type) {
     case _detail::format_arg_type::char_t:
         _detail::write_char(output, *static_cast<char const*>(_value), spec);

--- a/include/formatxx/_detail/format_arg_impl.h
+++ b/include/formatxx/_detail/format_arg_impl.h
@@ -36,7 +36,7 @@
 #include <cinttypes>
 
 template <typename CharT>
-formatxx::result_code FORMATXX_API formatxx::_detail::basic_format_arg<CharT>::format_into(basic_format_writer<CharT>& output, basic_string_view<CharT> spec) const {
+formatxx::result_code FORMATXX_API formatxx::_detail::basic_format_arg<CharT>::format_into(basic_format_writer<CharT>& output, basic_format_spec<CharT> spec) const {
     switch (_type) {
     case _detail::format_arg_type::char_t:
         _detail::write_char(output, *static_cast<char const*>(_value), spec);

--- a/include/formatxx/_detail/format_impl.h
+++ b/include/formatxx/_detail/format_impl.h
@@ -111,7 +111,7 @@ namespace formatxx::_detail {
                 }
 
                 spec = spec_result.spec;
-                spec.remaining = spec_result.unparsed;
+                spec.user = spec_result.unparsed;
 			}
 
 			// after the index/spec, we expect an end to the format marker

--- a/include/formatxx/_detail/format_impl.h
+++ b/include/formatxx/_detail/format_impl.h
@@ -33,6 +33,7 @@
 #pragma once
 
 #include "parse_unsigned.h"
+#include "parse_format.h"
 
 namespace formatxx::_detail {
 

--- a/include/formatxx/_detail/format_impl.h
+++ b/include/formatxx/_detail/format_impl.h
@@ -86,7 +86,7 @@ namespace formatxx::_detail {
 				index = next_index;
 			}
 
-			basic_string_view<CharT> spec;
+			basic_format_spec<CharT> spec;
 
 			// if a : follows the number, we have some formatting controls
 			if (*iter == FormatTraits<CharT>::cFormatSep) {
@@ -103,7 +103,14 @@ namespace formatxx::_detail {
 					break;
 				}
 
-				spec = basic_string_view<CharT>(spec_begin, iter);
+                basic_parse_spec_result<CharT> const spec_result = parse_format_spec<CharT>({ spec_begin, iter });
+                if (spec_result.code != result_code::success) {
+                    result = spec_result.code;
+                    break;
+                }
+
+                spec = spec_result.spec;
+                spec.remaining = spec_result.unparsed;
 			}
 
 			// after the index/spec, we expect an end to the format marker

--- a/include/formatxx/_detail/format_impl.h
+++ b/include/formatxx/_detail/format_impl.h
@@ -87,7 +87,7 @@ namespace formatxx::_detail {
 				index = next_index;
 			}
 
-			basic_format_spec<CharT> spec;
+			basic_format_options<CharT> options;
 
 			// if a : follows the number, we have some formatting controls
 			if (*iter == FormatTraits<CharT>::cFormatSep) {
@@ -99,7 +99,7 @@ namespace formatxx::_detail {
 				}
 
 				if (iter == end) {
-					// invalid spec
+					// invalid options
 					result = result_code::malformed_input;
 					break;
 				}
@@ -110,11 +110,11 @@ namespace formatxx::_detail {
                     break;
                 }
 
-                spec = spec_result.spec;
-                spec.user = spec_result.unparsed;
+                options = spec_result.options;
+                options.user = spec_result.unparsed;
 			}
 
-			// after the index/spec, we expect an end to the format marker
+			// after the index/options, we expect an end to the format marker
 			if (*iter != FormatTraits<CharT>::cFormatEnd) {
 				// we have something besides a number, no bueno
 				result = result_code::malformed_input;
@@ -122,7 +122,7 @@ namespace formatxx::_detail {
 				continue;
 			}
 
-			result_code const arg_result = args.format_arg(out, index, spec);
+			result_code const arg_result = args.format_arg(out, index, options);
 			if (arg_result != result_code::success) {
 				result = arg_result;
 			}

--- a/include/formatxx/_detail/format_traits.h
+++ b/include/formatxx/_detail/format_traits.h
@@ -51,12 +51,14 @@ namespace formatxx::_detail {
 		static constexpr char cPrintfSpec = '%';
 		static constexpr char cPrintfIndex = '$';
 
-		static constexpr string_view sTrue{ "true", 4 };
-		static constexpr string_view sFalse{ "false", 5 };
-        static constexpr string_view sNullptr{ "nullptr", 7 };
+		static constexpr string_view sTrue{ "true" };
+		static constexpr string_view sFalse{ "false" };
+        static constexpr string_view sNullptr{ "nullptr" };
 
-		static constexpr string_view sPrintfSpecifiers{ "bcCsSdioxXufFeEaAgGp", 20 };
-		static constexpr string_view sPrintfModifiers{ "hljztL", 6 };
+        static constexpr string_view sFormatSpecifiers{ "bcsdioxXfFeEaAgG" };
+
+		static constexpr string_view sPrintfSpecifiers{ "bcCsSdioxXufFeEaAgGp" };
+		static constexpr string_view sPrintfModifiers{ "hljztL" };
 
 		static constexpr char const sDecimalPairs[] =
 			"00010203040506070809"
@@ -88,12 +90,14 @@ namespace formatxx::_detail {
 		static constexpr wchar_t cPrintfSpec = L'%';
 		static constexpr wchar_t cPrintfIndex = L'$';
 
-		static constexpr wstring_view sTrue{ L"true", 4 };
-		static constexpr wstring_view sFalse{ L"false", 5 };
-        static constexpr wstring_view sNullptr{ L"nullptr", 7 };
+		static constexpr wstring_view sTrue{ L"true" };
+		static constexpr wstring_view sFalse{ L"false" };
+        static constexpr wstring_view sNullptr{ L"nullptr" };
 
-		static constexpr wstring_view sPrintfSpecifiers{ L"bcCsSdioxXufFeEaAgGp", 20 };
-		static constexpr wstring_view sPrintfModifiers{ L"hljztL", 6 };
+        static constexpr wstring_view sFormatSpecifiers{ L"bcsdioxXfFeEaAgG" };
+
+		static constexpr wstring_view sPrintfSpecifiers{ L"bcCsSdioxXufFeEaAgGp" };
+		static constexpr wstring_view sPrintfModifiers{ L"hljztL" };
 
 		static constexpr wchar_t const sDecimalPairs[] =
 			L"00010203040506070809"

--- a/include/formatxx/_detail/format_traits.h
+++ b/include/formatxx/_detail/format_traits.h
@@ -46,8 +46,7 @@ namespace formatxx::_detail {
 		static constexpr char cSpace = ' ';
 		static constexpr char cHash = '#';
 		static constexpr char cDot = '.';
-
-		static constexpr char to_digit(char c) { return c + '0'; }
+        static constexpr char cZero = '0';
 
 		static constexpr char cPrintfSpec = '%';
 		static constexpr char cPrintfIndex = '$';
@@ -84,8 +83,7 @@ namespace formatxx::_detail {
 		static constexpr wchar_t cSpace = L' ';
 		static constexpr wchar_t cHash = L'#';
 		static constexpr wchar_t cDot = L'.';
-
-		static constexpr wchar_t to_digit(wchar_t c) { return c + L'0'; }
+        static constexpr wchar_t cZero = L'0';
 
 		static constexpr wchar_t cPrintfSpec = L'%';
 		static constexpr wchar_t cPrintfIndex = L'$';

--- a/include/formatxx/_detail/parse_format.h
+++ b/include/formatxx/_detail/parse_format.h
@@ -74,7 +74,6 @@ namespace formatxx {
 
 		// read in precision, if present
 		if (start != end && *start == Traits::cDot) {
-            result.options.has_precision = true;
 			start = _detail::parse_unsigned(start + 1, end, result.options.precision);
 		}
 

--- a/include/formatxx/_detail/parse_format.h
+++ b/include/formatxx/_detail/parse_format.h
@@ -38,13 +38,13 @@
 namespace formatxx {
 
 	template <typename CharT>
-	FORMATXX_PUBLIC basic_parse_spec_result<CharT> FORMATXX_API parse_format_spec(basic_string_view<CharT> spec) noexcept {
+	FORMATXX_PUBLIC basic_parse_spec_result<CharT> FORMATXX_API parse_format_spec(basic_string_view<CharT> spec_string) noexcept {
 		using Traits = _detail::FormatTraits<CharT>;
 
         basic_parse_spec_result<CharT> result;
 
-        CharT const* start = spec.data();
-		CharT const* const end = start + spec.size();
+        CharT const* start = spec_string.data();
+		CharT const* const end = start + spec_string.size();
 
 		// flags
 		while (start != end) {

--- a/include/formatxx/_detail/parse_format.h
+++ b/include/formatxx/_detail/parse_format.h
@@ -54,7 +54,7 @@ namespace formatxx {
 			else if (*start == Traits::cMinus) {
 				result.spec.left_justify = true;
 			}
-			else if (*start == Traits::to_digit(0)) {
+			else if (*start == Traits::cZero) {
                 result.spec.leading_zeroes = true;
 			}
 			else if (*start == Traits::cSpace) {

--- a/include/formatxx/_detail/parse_format.h
+++ b/include/formatxx/_detail/parse_format.h
@@ -49,16 +49,16 @@ namespace formatxx {
 		// flags
 		while (start != end) {
 			if (*start == Traits::cPlus) {
-				result.spec.prepend_sign = true;
+				result.spec.prepend_sign = sign::always;
 			}
 			else if (*start == Traits::cMinus) {
-				result.spec.left_justify = true;
+				result.spec.pad_justify = justify::left;
 			}
 			else if (*start == Traits::cZero) {
                 result.spec.leading_zeroes = true;
 			}
 			else if (*start == Traits::cSpace) {
-                result.spec.prepend_space = true;
+                result.spec.prepend_sign = sign::space;
 			}
 			else if (*start == Traits::cHash) {
                 result.spec.alternate_form = true;
@@ -78,13 +78,8 @@ namespace formatxx {
 			start = _detail::parse_unsigned(start + 1, end, result.spec.precision);
 		}
 
-		// read in any of the modifiers like h or l that modify a type code (no effect in our system)
-		while (start != end && _detail::string_contains(Traits::sPrintfModifiers, *start)) {
-			++start;
-		}
-
-		// generic code specified option allowed (required for printf)
-		if (start != end && _detail::string_contains(Traits::sPrintfSpecifiers, *start)) {
+		// generic code specified option allowed (mostly to set options on numeric formatting)
+		if (start != end && _detail::string_contains(Traits::sFormatSpecifiers, *start)) {
             result.spec.code = *start++;
 		}
 

--- a/include/formatxx/_detail/parse_format.h
+++ b/include/formatxx/_detail/parse_format.h
@@ -49,16 +49,16 @@ namespace formatxx {
 		// flags
 		while (start != end) {
 			if (*start == Traits::cPlus) {
-				result.options.prepend_sign = sign::always;
+				result.options.sign = format_sign::always;
 			}
 			else if (*start == Traits::cMinus) {
-				result.options.pad_justify = justify::left;
+				result.options.justify = format_justify::left;
 			}
 			else if (*start == Traits::cZero) {
                 result.options.leading_zeroes = true;
 			}
 			else if (*start == Traits::cSpace) {
-                result.options.prepend_sign = sign::space;
+                result.options.sign = format_sign::space;
 			}
 			else if (*start == Traits::cHash) {
                 result.options.alternate_form = true;
@@ -80,7 +80,7 @@ namespace formatxx {
 
 		// generic code specified option allowed (mostly to set format_options on numeric formatting)
 		if (start != end && _detail::string_contains(Traits::sFormatSpecifiers, *start)) {
-            result.options.code = *start++;
+            result.options.specifier = *start++;
 		}
 
         result.unparsed = { start, end };

--- a/include/formatxx/_detail/parse_format.h
+++ b/include/formatxx/_detail/parse_format.h
@@ -49,19 +49,19 @@ namespace formatxx {
 		// flags
 		while (start != end) {
 			if (*start == Traits::cPlus) {
-				result.spec.prepend_sign = sign::always;
+				result.options.prepend_sign = sign::always;
 			}
 			else if (*start == Traits::cMinus) {
-				result.spec.pad_justify = justify::left;
+				result.options.pad_justify = justify::left;
 			}
 			else if (*start == Traits::cZero) {
-                result.spec.leading_zeroes = true;
+                result.options.leading_zeroes = true;
 			}
 			else if (*start == Traits::cSpace) {
-                result.spec.prepend_sign = sign::space;
+                result.options.prepend_sign = sign::space;
 			}
 			else if (*start == Traits::cHash) {
-                result.spec.alternate_form = true;
+                result.options.alternate_form = true;
 			}
 			else {
 				break;
@@ -70,17 +70,17 @@ namespace formatxx {
 		}
 
 		// read in width
-		start = _detail::parse_unsigned(start, end, result.spec.width);
+		start = _detail::parse_unsigned(start, end, result.options.width);
 
 		// read in precision, if present
 		if (start != end && *start == Traits::cDot) {
-            result.spec.has_precision = true;
-			start = _detail::parse_unsigned(start + 1, end, result.spec.precision);
+            result.options.has_precision = true;
+			start = _detail::parse_unsigned(start + 1, end, result.options.precision);
 		}
 
-		// generic code specified option allowed (mostly to set options on numeric formatting)
+		// generic code specified option allowed (mostly to set format_options on numeric formatting)
 		if (start != end && _detail::string_contains(Traits::sFormatSpecifiers, *start)) {
-            result.spec.code = *start++;
+            result.options.code = *start++;
 		}
 
         result.unparsed = { start, end };

--- a/include/formatxx/_detail/parse_printf.h
+++ b/include/formatxx/_detail/parse_printf.h
@@ -49,19 +49,19 @@ namespace formatxx {
         // flags
         while (start != end) {
             if (*start == Traits::cPlus) {
-                result.spec.prepend_sign = sign::always;
+                result.options.prepend_sign = sign::always;
             }
             else if (*start == Traits::cMinus) {
-                result.spec.pad_justify = justify::left;
+                result.options.pad_justify = justify::left;
             }
             else if (*start == Traits::cZero) {
-                result.spec.leading_zeroes = true;
+                result.options.leading_zeroes = true;
             }
             else if (*start == Traits::cSpace) {
-                result.spec.prepend_sign = sign::space;
+                result.options.prepend_sign = sign::space;
             }
             else if (*start == Traits::cHash) {
-                result.spec.alternate_form = true;
+                result.options.alternate_form = true;
             }
             else {
                 break;
@@ -70,12 +70,12 @@ namespace formatxx {
         }
 
         // read in width
-        start = _detail::parse_unsigned(start, end, result.spec.width);
+        start = _detail::parse_unsigned(start, end, result.options.width);
 
         // read in precision, if present
         if (start != end && *start == Traits::cDot) {
-            result.spec.has_precision = true;
-            start = _detail::parse_unsigned(start + 1, end, result.spec.precision);
+            result.options.has_precision = true;
+            start = _detail::parse_unsigned(start + 1, end, result.options.precision);
         }
 
         // read in any of the modifiers like h or l that modify a type code (no effect in our system)
@@ -88,7 +88,7 @@ namespace formatxx {
             result.code = result_code::malformed_input;
             return result;
         }
-        result.spec.code = *start++;
+        result.options.code = *start++;
 
         result.unparsed = { start, end };
         return result;

--- a/include/formatxx/_detail/parse_printf.h
+++ b/include/formatxx/_detail/parse_printf.h
@@ -74,7 +74,6 @@ namespace formatxx {
 
         // read in precision, if present
         if (start != end && *start == Traits::cDot) {
-            result.options.has_precision = true;
             start = _detail::parse_unsigned(start + 1, end, result.options.precision);
         }
 

--- a/include/formatxx/_detail/parse_printf.h
+++ b/include/formatxx/_detail/parse_printf.h
@@ -49,16 +49,16 @@ namespace formatxx {
         // flags
         while (start != end) {
             if (*start == Traits::cPlus) {
-                result.spec.prepend_sign = true;
+                result.spec.prepend_sign = sign::always;
             }
             else if (*start == Traits::cMinus) {
-                result.spec.left_justify = true;
+                result.spec.pad_justify = justify::left;
             }
             else if (*start == Traits::cZero) {
                 result.spec.leading_zeroes = true;
             }
             else if (*start == Traits::cSpace) {
-                result.spec.prepend_space = true;
+                result.spec.prepend_sign = sign::space;
             }
             else if (*start == Traits::cHash) {
                 result.spec.alternate_form = true;
@@ -83,13 +83,14 @@ namespace formatxx {
             ++start;
         }
 
-        // generic code specified option allowed (required for printf)
-        if (start != end && _detail::string_contains(Traits::sPrintfSpecifiers, *start)) {
-            result.spec.code = *start++;
+        // mandatory generic code
+        if (start == end || !_detail::string_contains(Traits::sPrintfSpecifiers, *start)) {
+            result.code = result_code::malformed_input;
+            return result;
         }
+        result.spec.code = *start++;
 
         result.unparsed = { start, end };
-
         return result;
     }
 

--- a/include/formatxx/_detail/parse_printf.h
+++ b/include/formatxx/_detail/parse_printf.h
@@ -38,13 +38,13 @@
 namespace formatxx {
 
     template <typename CharT>
-    FORMATXX_PUBLIC basic_parse_spec_result<CharT> FORMATXX_API parse_printf_spec(basic_string_view<CharT> spec) noexcept {
+    FORMATXX_PUBLIC basic_parse_spec_result<CharT> FORMATXX_API parse_printf_spec(basic_string_view<CharT> spec_string) noexcept {
         using Traits = _detail::FormatTraits<CharT>;
 
         basic_parse_spec_result<CharT> result;
 
-        CharT const* start = spec.data();
-        CharT const* const end = start + spec.size();
+        CharT const* start = spec_string.data();
+        CharT const* const end = start + spec_string.size();
 
         // flags
         while (start != end) {

--- a/include/formatxx/_detail/parse_printf.h
+++ b/include/formatxx/_detail/parse_printf.h
@@ -1,0 +1,98 @@
+// formatxx - C++ string formatting library.
+//
+// This is free and unencumbered software released into the public domain.
+// 
+// Anyone is free to copy, modify, publish, use, compile, sell, or
+// distribute this software, either in source code form or as a compiled
+// binary, for any purpose, commercial or non - commercial, and by any
+// means.
+// 
+// In jurisdictions that recognize copyright laws, the author or authors
+// of this software dedicate any and all copyright interest in the
+// software to the public domain. We make this dedication for the benefit
+// of the public at large and to the detriment of our heirs and
+// successors. We intend this dedication to be an overt act of
+// relinquishment in perpetuity of all present and future rights to this
+// software under copyright law.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+// 
+// For more information, please refer to <http://unlicense.org/>
+//
+// Authors:
+//   Sean Middleditch <sean@middleditch.us>
+
+#if !defined(_guard_FORMATXX_DETAIL_PARSE_PRINTF_H)
+#define _guard_FORMATXX_DETAIL_PARSE_PRINTF_H
+#pragma once
+
+#include "parse_unsigned.h"
+#include "format_util.h"
+
+namespace formatxx {
+
+    template <typename CharT>
+    FORMATXX_PUBLIC basic_parse_spec_result<CharT> FORMATXX_API parse_printf_spec(basic_string_view<CharT> spec) noexcept {
+        using Traits = _detail::FormatTraits<CharT>;
+
+        basic_parse_spec_result<CharT> result;
+
+        CharT const* start = spec.data();
+        CharT const* const end = start + spec.size();
+
+        // flags
+        while (start != end) {
+            if (*start == Traits::cPlus) {
+                result.spec.prepend_sign = true;
+            }
+            else if (*start == Traits::cMinus) {
+                result.spec.left_justify = true;
+            }
+            else if (*start == Traits::cZero) {
+                result.spec.leading_zeroes = true;
+            }
+            else if (*start == Traits::cSpace) {
+                result.spec.prepend_space = true;
+            }
+            else if (*start == Traits::cHash) {
+                result.spec.alternate_form = true;
+            }
+            else {
+                break;
+            }
+            ++start;
+        }
+
+        // read in width
+        start = _detail::parse_unsigned(start, end, result.spec.width);
+
+        // read in precision, if present
+        if (start != end && *start == Traits::cDot) {
+            result.spec.has_precision = true;
+            start = _detail::parse_unsigned(start + 1, end, result.spec.precision);
+        }
+
+        // read in any of the modifiers like h or l that modify a type code (no effect in our system)
+        while (start != end && _detail::string_contains(Traits::sPrintfModifiers, *start)) {
+            ++start;
+        }
+
+        // generic code specified option allowed (required for printf)
+        if (start != end && _detail::string_contains(Traits::sPrintfSpecifiers, *start)) {
+            result.spec.code = *start++;
+        }
+
+        result.unparsed = { start, end };
+
+        return result;
+    }
+
+} // namespace formatxx
+
+#endif // _guard_FORMATXX_DETAIL_PARSE_PRINTF_H

--- a/include/formatxx/_detail/parse_printf.h
+++ b/include/formatxx/_detail/parse_printf.h
@@ -49,16 +49,16 @@ namespace formatxx {
         // flags
         while (start != end) {
             if (*start == Traits::cPlus) {
-                result.options.prepend_sign = sign::always;
+                result.options.sign = format_sign::always;
             }
             else if (*start == Traits::cMinus) {
-                result.options.pad_justify = justify::left;
+                result.options.justify = format_justify::left;
             }
             else if (*start == Traits::cZero) {
                 result.options.leading_zeroes = true;
             }
             else if (*start == Traits::cSpace) {
-                result.options.prepend_sign = sign::space;
+                result.options.sign = format_sign::space;
             }
             else if (*start == Traits::cHash) {
                 result.options.alternate_form = true;
@@ -88,7 +88,7 @@ namespace formatxx {
             result.code = result_code::malformed_input;
             return result;
         }
-        result.options.code = *start++;
+        result.options.specifier = *start++;
 
         result.unparsed = { start, end };
         return result;

--- a/include/formatxx/_detail/printf_impl.h
+++ b/include/formatxx/_detail/printf_impl.h
@@ -32,6 +32,8 @@
 #define _guard_FORMATXX_DETAIL_PRINTF_IMPL_H
 #pragma once
 
+#include "parse_printf.h"
+
 namespace formatxx::_detail {
 
 	template <typename CharT>
@@ -114,7 +116,7 @@ namespace formatxx::_detail {
 				// parse forward through the specification and verify that it's correct and will
 				// properly decode in parse_format_spec later.
 				CharT const* const spec_begin = iter;
-                basic_parse_spec_result<CharT> const spec_result = parse_format_spec(basic_string_view<CharT>(iter, end));
+                basic_parse_spec_result<CharT> const spec_result = parse_printf_spec(basic_string_view<CharT>(iter, end));
                 if (spec_result.code != result_code::success) {
                     result = spec_result.code;
                     break;

--- a/include/formatxx/_detail/printf_impl.h
+++ b/include/formatxx/_detail/printf_impl.h
@@ -71,7 +71,7 @@ namespace formatxx::_detail {
 				continue;
 			}
 
-			basic_format_spec<CharT> spec;
+			basic_format_options<CharT> options;
 
 			// determine which argument we're going to format (optional in printf syntax)
 			unsigned index = 0;
@@ -109,7 +109,7 @@ namespace formatxx::_detail {
 					index = next_index;
 
 					// the decimal input had nothing to do with position; reset so the call to
-					// parse_format_spec ensures we have a valid spec, not something like 1#2.3
+					// parse_format_spec ensures we have a valid options, not something like 1#2.3
 					iter = start;
 				}
 
@@ -122,13 +122,13 @@ namespace formatxx::_detail {
                     break;
                 }
 
-                spec = spec_result.spec;
+                options = spec_result.options;
 
 				// prepare for next round
 				begin = iter = spec_result.unparsed.begin();
 			}
 
-            result_code const arg_result = args.format_arg(out, index, spec);
+            result_code const arg_result = args.format_arg(out, index, options);
 			if (arg_result != result_code::success) {
 				result = arg_result;
 			}

--- a/include/formatxx/_detail/printf_impl.h
+++ b/include/formatxx/_detail/printf_impl.h
@@ -122,12 +122,6 @@ namespace formatxx::_detail {
                     break;
                 }
 
-				if (spec_result.spec.code == CharT(0)) {
-					// invalid spec
-					result = result_code::malformed_input;
-					break;
-				}
-
                 spec = spec_result.spec;
 
 				// prepare for next round

--- a/include/formatxx/_detail/write_float.h
+++ b/include/formatxx/_detail/write_float.h
@@ -55,7 +55,7 @@ namespace formatxx::_detail {
 		*--fmt_ptr = 0;
 
 		// every sprint call must have a valid code (1)
-		switch (options.code) {
+		switch (options.specifier) {
 		case 'a':
 		case 'A':
 		case 'e':
@@ -64,7 +64,7 @@ namespace formatxx::_detail {
 		case 'F':
 		case 'g':
 		case 'G':
-			*--fmt_ptr = options.code;
+			*--fmt_ptr = options.specifier;
 			break;
 		default:
 			*--fmt_ptr = 'f';
@@ -78,14 +78,14 @@ namespace formatxx::_detail {
 		*--fmt_ptr = '*';
 
 		// these flags are mutually exclusive within themselves (1)
-        switch (options.prepend_sign) {
-        case sign::negative: break;
-        case sign::always: *--fmt_ptr = FormatTraits<CharT>::cPlus; break;
-        case sign::space: *--fmt_ptr = FormatTraits<CharT>::cSpace; break;
+        switch (options.sign) {
+        case format_sign::negative: break;
+        case format_sign::always: *--fmt_ptr = FormatTraits<CharT>::cPlus; break;
+        case format_sign::space: *--fmt_ptr = FormatTraits<CharT>::cSpace; break;
 		}
 
 		// these flags may all be set together (3)
-		if (options.pad_justify == justify::left) {
+		if (options.justify == format_justify::left) {
 			*--fmt_ptr = '-';
 		}
 		if (options.leading_zeroes) {

--- a/include/formatxx/_detail/write_float.h
+++ b/include/formatxx/_detail/write_float.h
@@ -101,7 +101,7 @@ namespace formatxx::_detail {
 		constexpr std::size_t buf_size = 1078;
 		CharT buf[buf_size];
 
-		int const result = float_helper(buf, buf_size, fmt_ptr, options.width, options.has_precision ? options.precision : -1, value);
+		int const result = float_helper(buf, buf_size, fmt_ptr, options.width, options.precision, value);
 		if (result > 0) {
 			out.write({ buf, result < buf_size ? std::size_t(result) : buf_size });
 		}

--- a/include/formatxx/_detail/write_float.h
+++ b/include/formatxx/_detail/write_float.h
@@ -78,15 +78,14 @@ namespace formatxx::_detail {
 		*--fmt_ptr = '*';
 
 		// these flags are mutually exclusive within themselves (1)
-		if (spec.prepend_sign) {
-			*--fmt_ptr = FormatTraits<CharT>::cPlus;
-		}
-		else if (spec.prepend_space) {
-			*--fmt_ptr = FormatTraits<CharT>::cSpace;
+        switch (spec.prepend_sign) {
+        case sign::negative: break;
+        case sign::always: *--fmt_ptr = FormatTraits<CharT>::cPlus; break;
+        case sign::space: *--fmt_ptr = FormatTraits<CharT>::cSpace; break;
 		}
 
 		// these flags may all be set together (3)
-		if (spec.left_justify) {
+		if (spec.pad_justify == justify::left) {
 			*--fmt_ptr = '-';
 		}
 		if (spec.leading_zeroes) {

--- a/include/formatxx/_detail/write_float.h
+++ b/include/formatxx/_detail/write_float.h
@@ -46,9 +46,7 @@ namespace formatxx::_detail {
 	}
 
 	template <typename CharT>
-	void write_float(basic_format_writer<CharT>& out, double value, basic_string_view<CharT> spec_string) {
-		auto const spec = parse_format_spec(spec_string);
-
+	void write_float(basic_format_writer<CharT>& out, double value, basic_format_spec<CharT> spec) {
 		constexpr std::size_t fmt_buf_size = 10;
 		CharT fmt_buf[fmt_buf_size];
 		CharT* fmt_ptr = fmt_buf + fmt_buf_size;

--- a/include/formatxx/_detail/write_float.h
+++ b/include/formatxx/_detail/write_float.h
@@ -46,7 +46,7 @@ namespace formatxx::_detail {
 	}
 
 	template <typename CharT>
-	void write_float(basic_format_writer<CharT>& out, double value, basic_format_spec<CharT> spec) {
+	void write_float(basic_format_writer<CharT>& out, double value, basic_format_options<CharT> options) {
 		constexpr std::size_t fmt_buf_size = 10;
 		CharT fmt_buf[fmt_buf_size];
 		CharT* fmt_ptr = fmt_buf + fmt_buf_size;
@@ -55,7 +55,7 @@ namespace formatxx::_detail {
 		*--fmt_ptr = 0;
 
 		// every sprint call must have a valid code (1)
-		switch (spec.code) {
+		switch (options.code) {
 		case 'a':
 		case 'A':
 		case 'e':
@@ -64,7 +64,7 @@ namespace formatxx::_detail {
 		case 'F':
 		case 'g':
 		case 'G':
-			*--fmt_ptr = spec.code;
+			*--fmt_ptr = options.code;
 			break;
 		default:
 			*--fmt_ptr = 'f';
@@ -78,20 +78,20 @@ namespace formatxx::_detail {
 		*--fmt_ptr = '*';
 
 		// these flags are mutually exclusive within themselves (1)
-        switch (spec.prepend_sign) {
+        switch (options.prepend_sign) {
         case sign::negative: break;
         case sign::always: *--fmt_ptr = FormatTraits<CharT>::cPlus; break;
         case sign::space: *--fmt_ptr = FormatTraits<CharT>::cSpace; break;
 		}
 
 		// these flags may all be set together (3)
-		if (spec.pad_justify == justify::left) {
+		if (options.pad_justify == justify::left) {
 			*--fmt_ptr = '-';
 		}
-		if (spec.leading_zeroes) {
+		if (options.leading_zeroes) {
 			*--fmt_ptr = '0';
 		}
-		if (spec.alternate_form) {
+		if (options.alternate_form) {
 			*--fmt_ptr = FormatTraits<CharT>::cHash;
 		}
 
@@ -101,7 +101,7 @@ namespace formatxx::_detail {
 		constexpr std::size_t buf_size = 1078;
 		CharT buf[buf_size];
 
-		int const result = float_helper(buf, buf_size, fmt_ptr, spec.width, spec.has_precision ? spec.precision : -1, value);
+		int const result = float_helper(buf, buf_size, fmt_ptr, options.width, options.has_precision ? options.precision : -1, value);
 		if (result > 0) {
 			out.write({ buf, result < buf_size ? std::size_t(result) : buf_size });
 		}

--- a/include/formatxx/_detail/write_integer.h
+++ b/include/formatxx/_detail/write_integer.h
@@ -39,7 +39,7 @@
 
 namespace formatxx::_detail {
 
-	template <typename CharT, typename T> void write_integer(basic_format_writer<CharT>& out, T value, basic_string_view<CharT> spec);
+	template <typename CharT, typename T> void write_integer(basic_format_writer<CharT>& out, T value, basic_format_spec<CharT> spec);
 
 	struct prefix_helper {
 		// type prefix (2), sign (1)
@@ -180,7 +180,7 @@ namespace formatxx::_detail {
 	};
 
 	template <typename HelperT, typename CharT, typename ValueT>
-	void write_integer_helper(basic_format_writer<CharT> & out, ValueT raw_value, basic_format_spec<CharT> const& spec) {
+	void write_integer_helper(basic_format_writer<CharT> & out, ValueT raw_value, basic_format_spec<CharT> spec) {
 		using unsigned_type = std::make_unsigned_t<ValueT>;
 
 		// convert to an unsigned value to make the formatting easier; note that must
@@ -223,9 +223,7 @@ namespace formatxx::_detail {
 	}
 
 	template <typename CharT, typename T>
-	void write_integer(basic_format_writer<CharT> & out, T raw, basic_string_view<CharT> spec_string) {
-		basic_format_spec<CharT> spec = parse_format_spec(spec_string);
-
+	void write_integer(basic_format_writer<CharT> & out, T raw, basic_format_spec<CharT> spec) {
 		switch (spec.code) {
 		default:
 		case 0:

--- a/include/formatxx/_detail/write_integer.h
+++ b/include/formatxx/_detail/write_integer.h
@@ -60,10 +60,10 @@ namespace formatxx::_detail {
 			if (negative) {
 				*--ptr = FormatTraits<CharT>::cMinus;
 			}
-			else if (spec.prepend_sign) {
+			else if (spec.prepend_sign == sign::always) {
 				*--ptr = FormatTraits<CharT>::cPlus;
 			}
-			else if (spec.prepend_space) {
+			else if (spec.prepend_sign == sign::space) {
 				*--ptr = FormatTraits<CharT>::cSpace;
 			}
 
@@ -204,7 +204,7 @@ namespace formatxx::_detail {
 			std::size_t const output_length = prefix.size() + result.size();
 			std::size_t const padding = spec.width > output_length ? spec.width - output_length : 0;
 
-			if (spec.left_justify) {
+			if (spec.pad_justify == justify::left) {
 				out.write(prefix);
 				out.write(result);
 				write_padding(out, FormatTraits<CharT>::cSpace, padding);
@@ -228,23 +228,19 @@ namespace formatxx::_detail {
 		default:
 		case 0:
 		case 'i':
-			spec.code = 'd'; // code is used literally in alt-form, and 'd' is decimal code
-			return write_integer_helper<decimal_helper>(out, raw, spec);
 		case 'd':
 		case 'D':
 			return write_integer_helper<decimal_helper>(out, raw, spec);
 		case 'x':
-			spec.prepend_sign = spec.prepend_space = false; // ignored on hex numbers
+            spec.prepend_sign = sign::negative; // ignored on hex numbers
 			return write_integer_helper<hexadecimal_helper</*lower=*/true>>(out, std::make_unsigned_t<T>(raw), spec);
 		case 'X':
-			spec.prepend_sign = spec.prepend_space = false; // ignored on hex numbers
+            spec.prepend_sign = sign::negative; // ignored on hex numbers
 			return write_integer_helper<hexadecimal_helper</*lower=*/false>>(out, std::make_unsigned_t<T>(raw), spec);
 		case 'o':
-		case 'O':
 			return write_integer_helper<octal_helper>(out, raw, spec);
 			break;
 		case 'b':
-		case 'B':
 			return write_integer_helper<binary_helper>(out, raw, spec);
 			break;
 		}

--- a/include/formatxx/_detail/write_integer.h
+++ b/include/formatxx/_detail/write_integer.h
@@ -52,7 +52,7 @@ namespace formatxx::_detail {
 
 			// add numeric type prefix (2)
 			if (options.alternate_form) {
-				*--ptr = options.code;
+				*--ptr = options.specifier;
 				*--ptr = FormatTraits<CharT>::cZero;
 			}
 
@@ -61,10 +61,10 @@ namespace formatxx::_detail {
                 if (negative) {
                     *--ptr = FormatTraits<CharT>::cMinus;
                 }
-                else if (options.prepend_sign == sign::always) {
+                else if (options.sign == format_sign::always) {
                     *--ptr = FormatTraits<CharT>::cPlus;
                 }
-                else if (options.prepend_sign == sign::space) {
+                else if (options.sign == format_sign::space) {
                     *--ptr = FormatTraits<CharT>::cSpace;
                 }
             }
@@ -214,7 +214,7 @@ namespace formatxx::_detail {
 			std::size_t const output_length = prefix.size() + result.size();
 			std::size_t const padding = options.width > output_length ? options.width - output_length : 0;
 
-			if (options.pad_justify == justify::left) {
+			if (options.justify == format_justify::left) {
 				out.write(prefix);
 				out.write(result);
 				write_padding(out, FormatTraits<CharT>::cSpace, padding);
@@ -234,7 +234,7 @@ namespace formatxx::_detail {
 
 	template <typename CharT, typename T>
 	void write_integer(basic_format_writer<CharT> & out, T raw, basic_format_options<CharT> const& options) {
-		switch (options.code) {
+		switch (options.specifier) {
 		default:
 		case 0:
 		case 'i':

--- a/include/formatxx/_detail/write_integer.h
+++ b/include/formatxx/_detail/write_integer.h
@@ -206,7 +206,7 @@ namespace formatxx::_detail {
 		CharT value_buffer[HelperT::template buffer_size<unsigned_type>];
 		auto const result = HelperT::write(value_buffer, unsigned_value);
 
-		if (options.has_precision) {
+		if (options.precision != ~0u) {
 			out.write(prefix);
 			write_padded_align_right(out, result, FormatTraits<CharT>::cZero, options.precision);
 		}

--- a/include/formatxx/_detail/write_integer.h
+++ b/include/formatxx/_detail/write_integer.h
@@ -53,7 +53,7 @@ namespace formatxx::_detail {
 			// add numeric type prefix (2)
 			if (spec.alternate_form) {
 				*--ptr = spec.code;
-				*--ptr = FormatTraits<CharT>::to_digit(0);
+				*--ptr = FormatTraits<CharT>::cZero;
 			}
 
 			// add sign (1)
@@ -109,7 +109,7 @@ namespace formatxx::_detail {
 			}
 			else {
 				// we have but a single digit left, so this is easy
-				*--ptr = FormatTraits<CharT>::to_digit(static_cast<char>(value));
+				*--ptr = static_cast<char>(FormatTraits<CharT>::cZero + value);
 			}
 
 			return { ptr, end };
@@ -172,7 +172,7 @@ namespace formatxx::_detail {
 			CharT* ptr = end;
 
 			do {
-				*--ptr = FormatTraits<CharT>::to_digit(value & 1);
+				*--ptr = static_cast<CharT>(FormatTraits<CharT>::cZero + (value & 1));
 			} while ((value >>= 1) != 0);
 
 			return { ptr, end };
@@ -198,7 +198,7 @@ namespace formatxx::_detail {
 
 		if (spec.has_precision) {
 			out.write(prefix);
-			write_padded_align_right(out, result, FormatTraits<CharT>::to_digit(0), spec.precision);
+			write_padded_align_right(out, result, FormatTraits<CharT>::cZero, spec.precision);
 		}
 		else {
 			std::size_t const output_length = prefix.size() + result.size();
@@ -211,7 +211,7 @@ namespace formatxx::_detail {
 			}
 			else if (spec.leading_zeroes) {
 				out.write(prefix);
-				write_padding(out, FormatTraits<CharT>::to_digit(0), padding);
+				write_padding(out, FormatTraits<CharT>::cZero, padding);
 				out.write(result);
 			}
 			else {
@@ -235,10 +235,10 @@ namespace formatxx::_detail {
 			return write_integer_helper<decimal_helper>(out, raw, spec);
 		case 'x':
 			spec.prepend_sign = spec.prepend_space = false; // ignored on hex numbers
-			return write_integer_helper<hexadecimal_helper</*lower=*/true>>(out, typename std::make_unsigned<T>::type(raw), spec);
+			return write_integer_helper<hexadecimal_helper</*lower=*/true>>(out, std::make_unsigned_t<T>(raw), spec);
 		case 'X':
 			spec.prepend_sign = spec.prepend_space = false; // ignored on hex numbers
-			return write_integer_helper<hexadecimal_helper</*lower=*/false>>(out, typename std::make_unsigned<T>::type(raw), spec);
+			return write_integer_helper<hexadecimal_helper</*lower=*/false>>(out, std::make_unsigned_t<T>(raw), spec);
 		case 'o':
 		case 'O':
 			return write_integer_helper<octal_helper>(out, raw, spec);

--- a/include/formatxx/_detail/write_string.h
+++ b/include/formatxx/_detail/write_string.h
@@ -37,7 +37,7 @@
 namespace formatxx::_detail {
 
 	template <typename CharT>
-	void write_string(basic_format_writer<CharT>& out, basic_string_view<CharT> str, basic_format_spec<CharT> spec) {
+	void write_string(basic_format_writer<CharT>& out, basic_string_view<CharT> str, basic_format_spec<CharT> const& spec) {
 		if (spec.has_precision) {
 			str = trim_string(str, spec.precision);
 		}
@@ -51,7 +51,7 @@ namespace formatxx::_detail {
 	}
 
 	template <typename CharT>
-	void write_char(basic_format_writer<CharT>& out, CharT ch, basic_format_spec<CharT> spec) {
+	void write_char(basic_format_writer<CharT>& out, CharT ch, basic_format_spec<CharT> const& spec) {
 		write_string(out, { &ch, 1 }, spec);
 	}
 

--- a/include/formatxx/_detail/write_string.h
+++ b/include/formatxx/_detail/write_string.h
@@ -42,7 +42,7 @@ namespace formatxx::_detail {
 			str = trim_string(str, spec.precision);
 		}
 
-		if (!spec.left_justify) {
+		if (spec.pad_justify == justify::right) {
 			write_padded_align_right(out, str, FormatTraits<CharT>::cSpace, spec.width);
 		}
         else {

--- a/include/formatxx/_detail/write_string.h
+++ b/include/formatxx/_detail/write_string.h
@@ -42,7 +42,7 @@ namespace formatxx::_detail {
 			str = trim_string(str, options.precision);
 		}
 
-		if (options.pad_justify == justify::right) {
+		if (options.justify == format_justify::right) {
 			write_padded_align_right(out, str, FormatTraits<CharT>::cSpace, options.width);
 		}
         else {

--- a/include/formatxx/_detail/write_string.h
+++ b/include/formatxx/_detail/write_string.h
@@ -37,22 +37,22 @@
 namespace formatxx::_detail {
 
 	template <typename CharT>
-	void write_string(basic_format_writer<CharT>& out, basic_string_view<CharT> str, basic_format_spec<CharT> const& spec) {
-		if (spec.has_precision) {
-			str = trim_string(str, spec.precision);
+	void write_string(basic_format_writer<CharT>& out, basic_string_view<CharT> str, basic_format_options<CharT> const& options) {
+		if (options.has_precision) {
+			str = trim_string(str, options.precision);
 		}
 
-		if (spec.pad_justify == justify::right) {
-			write_padded_align_right(out, str, FormatTraits<CharT>::cSpace, spec.width);
+		if (options.pad_justify == justify::right) {
+			write_padded_align_right(out, str, FormatTraits<CharT>::cSpace, options.width);
 		}
         else {
-			write_padded_align_left(out, str, FormatTraits<CharT>::cSpace, spec.width);
+			write_padded_align_left(out, str, FormatTraits<CharT>::cSpace, options.width);
 		}
 	}
 
 	template <typename CharT>
-	void write_char(basic_format_writer<CharT>& out, CharT ch, basic_format_spec<CharT> const& spec) {
-		write_string(out, { &ch, 1 }, spec);
+	void write_char(basic_format_writer<CharT>& out, CharT ch, basic_format_options<CharT> const& options) {
+		write_string(out, { &ch, 1 }, options);
 	}
 
 } // namespace formatxx::_detail

--- a/include/formatxx/_detail/write_string.h
+++ b/include/formatxx/_detail/write_string.h
@@ -38,7 +38,7 @@ namespace formatxx::_detail {
 
 	template <typename CharT>
 	void write_string(basic_format_writer<CharT>& out, basic_string_view<CharT> str, basic_format_options<CharT> const& options) {
-		if (options.has_precision) {
+		if (options.precision != ~0u) {
 			str = trim_string(str, options.precision);
 		}
 

--- a/include/formatxx/_detail/write_string.h
+++ b/include/formatxx/_detail/write_string.h
@@ -37,9 +37,7 @@
 namespace formatxx::_detail {
 
 	template <typename CharT>
-	void write_string(basic_format_writer<CharT>& out, basic_string_view<CharT> str, basic_string_view<CharT> spec_string) {
-		auto const spec = parse_format_spec(spec_string);
-
+	void write_string(basic_format_writer<CharT>& out, basic_string_view<CharT> str, basic_format_spec<CharT> spec) {
 		if (spec.has_precision) {
 			str = trim_string(str, spec.precision);
 		}
@@ -53,7 +51,7 @@ namespace formatxx::_detail {
 	}
 
 	template <typename CharT>
-	void write_char(basic_format_writer<CharT>& out, CharT ch, basic_string_view<CharT> spec) {
+	void write_char(basic_format_writer<CharT>& out, CharT ch, basic_format_spec<CharT> spec) {
 		write_string(out, { &ch, 1 }, spec);
 	}
 

--- a/include/formatxx/_detail/write_wide.h
+++ b/include/formatxx/_detail/write_wide.h
@@ -41,51 +41,41 @@ namespace formatxx::_detail {
 #pragma warning(push)
 #pragma warning(disable: 4996)
 
-    inline void write_char(wformat_writer& out, char ch, wstring_view) noexcept
-    {
+    inline void write_char(wformat_writer& out, char ch, wformat_spec) noexcept {
         std::mbstate_t state{};
         wchar_t wc;
         std::size_t const rs = std::mbrtowc(&wc, &ch, 1, &state);
-        if (rs > 0 && rs < static_cast<std::size_t>(-2))
-        {
+        if (rs > 0 && rs < static_cast<std::size_t>(-2)) {
             out.write({ &wc, 1 });
         }
     }
 
-    inline void write_string(wformat_writer& out, string_view str, wstring_view) noexcept
-    {
+    inline void write_string(wformat_writer& out, string_view str, wformat_spec) noexcept {
         std::mbstate_t state{};
-        for (auto const ch : str)
-        {
+        for (auto const ch : str) {
             wchar_t wc;
             std::size_t const rs = std::mbrtowc(&wc, &ch, 1, &state);
-            if (rs < static_cast<std::size_t>(-2))
-            {
+            if (rs < static_cast<std::size_t>(-2)) {
                 out.write({ &wc, 1 });
             }
         }
     }
 
-    inline void write_char(format_writer& out, wchar_t ch, string_view) noexcept
-    {
+    inline void write_char(format_writer& out, wchar_t ch, format_spec) noexcept {
         std::mbstate_t state{};
         char mb[MB_LEN_MAX];
         std::size_t const rs = std::wcrtomb(mb, ch, &state);
-        if (rs != static_cast<std::size_t>(-1))
-        {
+        if (rs != static_cast<std::size_t>(-1)) {
             out.write({ mb, rs });
         }
     }
 
-    inline void write_string(format_writer& out, wstring_view str, string_view) noexcept
-    {
+    inline void write_string(format_writer& out, wstring_view str, format_spec) noexcept {
         std::mbstate_t state{};
         char mb[MB_LEN_MAX];
-        for (auto const ch : str)
-        {
+        for (auto const ch : str) {
             std::size_t const rs = std::wcrtomb(mb, ch, &state);
-            if (rs != static_cast<std::size_t>(-1))
-            {
+            if (rs != static_cast<std::size_t>(-1)) {
                 out.write({ mb, rs });
             }
         }

--- a/include/formatxx/_detail/write_wide.h
+++ b/include/formatxx/_detail/write_wide.h
@@ -41,7 +41,7 @@ namespace formatxx::_detail {
 #pragma warning(push)
 #pragma warning(disable: 4996)
 
-    inline void write_char(wformat_writer& out, char ch, wformat_spec const&) noexcept {
+    inline void write_char(wformat_writer& out, char ch, wformat_options const&) noexcept {
         std::mbstate_t state{};
         wchar_t wc;
         std::size_t const rs = std::mbrtowc(&wc, &ch, 1, &state);
@@ -50,7 +50,7 @@ namespace formatxx::_detail {
         }
     }
 
-    inline void write_string(wformat_writer& out, string_view str, wformat_spec const&) noexcept {
+    inline void write_string(wformat_writer& out, string_view str, wformat_options const&) noexcept {
         std::mbstate_t state{};
         for (auto const ch : str) {
             wchar_t wc;
@@ -61,7 +61,7 @@ namespace formatxx::_detail {
         }
     }
 
-    inline void write_char(format_writer& out, wchar_t ch, format_spec const&) noexcept {
+    inline void write_char(format_writer& out, wchar_t ch, format_options const&) noexcept {
         std::mbstate_t state{};
         char mb[MB_LEN_MAX];
         std::size_t const rs = std::wcrtomb(mb, ch, &state);
@@ -70,7 +70,7 @@ namespace formatxx::_detail {
         }
     }
 
-    inline void write_string(format_writer& out, wstring_view str, format_spec const&) noexcept {
+    inline void write_string(format_writer& out, wstring_view str, format_options const&) noexcept {
         std::mbstate_t state{};
         char mb[MB_LEN_MAX];
         for (auto const ch : str) {

--- a/include/formatxx/_detail/write_wide.h
+++ b/include/formatxx/_detail/write_wide.h
@@ -41,7 +41,7 @@ namespace formatxx::_detail {
 #pragma warning(push)
 #pragma warning(disable: 4996)
 
-    inline void write_char(wformat_writer& out, char ch, wformat_spec) noexcept {
+    inline void write_char(wformat_writer& out, char ch, wformat_spec const&) noexcept {
         std::mbstate_t state{};
         wchar_t wc;
         std::size_t const rs = std::mbrtowc(&wc, &ch, 1, &state);
@@ -50,7 +50,7 @@ namespace formatxx::_detail {
         }
     }
 
-    inline void write_string(wformat_writer& out, string_view str, wformat_spec) noexcept {
+    inline void write_string(wformat_writer& out, string_view str, wformat_spec const&) noexcept {
         std::mbstate_t state{};
         for (auto const ch : str) {
             wchar_t wc;
@@ -61,7 +61,7 @@ namespace formatxx::_detail {
         }
     }
 
-    inline void write_char(format_writer& out, wchar_t ch, format_spec) noexcept {
+    inline void write_char(format_writer& out, wchar_t ch, format_spec const&) noexcept {
         std::mbstate_t state{};
         char mb[MB_LEN_MAX];
         std::size_t const rs = std::wcrtomb(mb, ch, &state);
@@ -70,7 +70,7 @@ namespace formatxx::_detail {
         }
     }
 
-    inline void write_string(format_writer& out, wstring_view str, format_spec) noexcept {
+    inline void write_string(format_writer& out, wstring_view str, format_spec const&) noexcept {
         std::mbstate_t state{};
         char mb[MB_LEN_MAX];
         for (auto const ch : str) {

--- a/include/formatxx/format.h
+++ b/include/formatxx/format.h
@@ -134,15 +134,14 @@ public:
 template <typename CharT>
 class formatxx::basic_format_options {
 public:
-    constexpr basic_format_options() noexcept : has_precision(false), alternate_form(false), leading_zeroes(false) {}
+    constexpr basic_format_options() noexcept : alternate_form(false), leading_zeroes(false) {}
 
     basic_string_view<CharT> user;
     unsigned width = 0;
-    unsigned precision = 0;
+    unsigned precision = ~0u;
     CharT specifier = 0;
     format_justify justify = format_justify::right;
     format_sign sign = format_sign::negative;
-    bool has_precision : 1;
     bool alternate_form : 1;
     bool leading_zeroes : 1;
 };

--- a/include/formatxx/format.h
+++ b/include/formatxx/format.h
@@ -136,7 +136,7 @@ class formatxx::basic_format_spec {
 public:
     constexpr basic_format_spec() noexcept : has_precision(false), alternate_form(false), leading_zeroes(false) {}
 
-    basic_string_view<CharT> remaining;
+    basic_string_view<CharT> user;
     unsigned width = 0;
     unsigned precision = 0;
     CharT code = 0;

--- a/include/formatxx/format.h
+++ b/include/formatxx/format.h
@@ -134,7 +134,7 @@ public:
 template <typename CharT>
 class formatxx::basic_format_spec {
 public:
-    basic_format_spec() : has_precision(false), alternate_form(false), leading_zeroes(false) {}
+    constexpr basic_format_spec() noexcept : has_precision(false), alternate_form(false), leading_zeroes(false) {}
 
     basic_string_view<CharT> remaining;
     unsigned width = 0;

--- a/include/formatxx/format.h
+++ b/include/formatxx/format.h
@@ -119,16 +119,18 @@ public:
 template <typename CharT>
 class formatxx::basic_format_spec {
 public:
+    basic_format_spec() : has_precision(false), left_justify(false), prepend_sign(false), prepend_space(false), alternate_form(false), leading_zeroes(false) {}
+
     basic_string_view<CharT> remaining;
     unsigned width = 0;
     unsigned precision = 0;
     CharT code = 0;
-    bool has_precision = false;
-    bool left_justify = false;
-    bool prepend_sign = false;
-    bool prepend_space = false;
-    bool alternate_form = false;
-    bool leading_zeroes = false;
+    bool has_precision : 1;
+    bool left_justify : 1;
+    bool prepend_sign : 1;
+    bool prepend_space : 1;
+    bool alternate_form : 1;
+    bool leading_zeroes : 1;
 };
 
 namespace formatxx {

--- a/include/formatxx/format.h
+++ b/include/formatxx/format.h
@@ -64,8 +64,8 @@ namespace formatxx {
     template <typename CharT> class basic_parse_spec_result;
 
     enum class result_code : unsigned int;
-    enum class justify : unsigned char;
-    enum class sign : unsigned char;
+    enum class format_justify : unsigned char;
+    enum class format_sign : unsigned char;
 
     using string_view = basic_string_view<char>;
     using format_writer = basic_format_writer<char>;
@@ -95,13 +95,13 @@ enum class formatxx::result_code : unsigned int {
     out_of_space,
 };
 
-enum class formatxx::justify : unsigned char {
+enum class formatxx::format_justify : unsigned char {
     right,
     left,
     center
 };
 
-enum class formatxx::sign : unsigned char {
+enum class formatxx::format_sign : unsigned char {
     negative,
     always,
     space
@@ -139,9 +139,9 @@ public:
     basic_string_view<CharT> user;
     unsigned width = 0;
     unsigned precision = 0;
-    CharT code = 0;
-    justify pad_justify = justify::right;
-    sign prepend_sign = sign::negative;
+    CharT specifier = 0;
+    format_justify justify = format_justify::right;
+    format_sign sign = format_sign::negative;
     bool has_precision : 1;
     bool alternate_form : 1;
     bool leading_zeroes : 1;

--- a/include/formatxx/format.h
+++ b/include/formatxx/format.h
@@ -83,6 +83,7 @@ namespace formatxx {
     result_code format_value_to(basic_format_writer<CharT>& writer, T const& value, basic_format_spec<CharT> spec = {});
 
     template <typename CharT> FORMATXX_PUBLIC basic_parse_spec_result<CharT> FORMATXX_API parse_format_spec(basic_string_view<CharT> spec) noexcept;
+    template <typename CharT> FORMATXX_PUBLIC basic_parse_spec_result<CharT> FORMATXX_API parse_printf_spec(basic_string_view<CharT> spec) noexcept;
 }
 
 enum class formatxx::result_code {
@@ -153,11 +154,13 @@ extern template FORMATXX_PUBLIC formatxx::result_code FORMATXX_API formatxx::_de
 extern template FORMATXX_PUBLIC formatxx::result_code FORMATXX_API formatxx::_detail::printf_impl(basic_format_writer<char>& out, basic_string_view<char> format, basic_format_arg_list<char> args);
 extern template FORMATXX_PUBLIC formatxx::result_code FORMATXX_API formatxx::_detail::basic_format_arg<char>::format_into(basic_format_writer<char>& output, basic_format_spec<char> spec) const;
 extern template FORMATXX_PUBLIC formatxx::basic_parse_spec_result<char> FORMATXX_API formatxx::parse_format_spec(basic_string_view<char> spec) noexcept;
+extern template FORMATXX_PUBLIC formatxx::basic_parse_spec_result<char> FORMATXX_API formatxx::parse_printf_spec(basic_string_view<char> spec) noexcept;
 
 extern template FORMATXX_PUBLIC formatxx::result_code FORMATXX_API formatxx::_detail::format_impl(basic_format_writer<wchar_t>& out, basic_string_view<wchar_t> format, basic_format_arg_list<wchar_t> args);
 extern template FORMATXX_PUBLIC formatxx::result_code FORMATXX_API formatxx::_detail::printf_impl(basic_format_writer<wchar_t>& out, basic_string_view<wchar_t> format, basic_format_arg_list<wchar_t> args);
 extern template FORMATXX_PUBLIC formatxx::result_code FORMATXX_API formatxx::_detail::basic_format_arg<wchar_t>::format_into(basic_format_writer<wchar_t>& output, basic_format_spec<wchar_t> spec) const;
 extern template FORMATXX_PUBLIC formatxx::basic_parse_spec_result<wchar_t> FORMATXX_API formatxx::parse_format_spec(basic_string_view<wchar_t> spec) noexcept;
+extern template FORMATXX_PUBLIC formatxx::basic_parse_spec_result<wchar_t> FORMATXX_API formatxx::parse_printf_spec(basic_string_view<wchar_t> spec) noexcept;
 
 /// Write the string format using the given parameters into a buffer.
 /// @param writer The write buffer that will receive the formatted text.

--- a/include/formatxx/format.h
+++ b/include/formatxx/format.h
@@ -60,7 +60,7 @@
 namespace formatxx {
     template <typename CharT> using basic_string_view = litexx::basic_string_view<CharT>;
     template <typename CharT> class basic_format_writer;
-    template <typename CharT> class basic_format_spec;
+    template <typename CharT> class basic_format_options;
     template <typename CharT> class basic_parse_spec_result;
 
     enum class result_code : unsigned int;
@@ -69,11 +69,11 @@ namespace formatxx {
 
     using string_view = basic_string_view<char>;
     using format_writer = basic_format_writer<char>;
-    using format_spec = basic_format_spec<char>;
+    using format_options = basic_format_options<char>;
 
     using wstring_view = basic_string_view<wchar_t>;
     using wformat_writer = basic_format_writer<wchar_t>;
-    using wformat_spec = basic_format_spec<wchar_t>;
+    using wformat_options = basic_format_options<wchar_t>;
 
     template <typename CharT, typename FormatT, typename... Args> result_code format_to(basic_format_writer<CharT>& writer, FormatT const& format, Args const& ... args);
     template <typename CharT, typename FormatT, typename... Args> result_code printf_to(basic_format_writer<CharT>& writer, FormatT const& format, Args const& ... args);
@@ -82,7 +82,7 @@ namespace formatxx {
     template <typename ResultT, typename FormatT, typename... Args> ResultT printf_as(FormatT const& format, Args const& ... args);
 
     template <typename CharT, typename T>
-    result_code format_value_to(basic_format_writer<CharT>& writer, T const& value, basic_format_spec<CharT> spec = {});
+    result_code format_value_to(basic_format_writer<CharT>& writer, T const& value, basic_format_options<CharT> const& options = {});
 
     template <typename CharT> FORMATXX_PUBLIC basic_parse_spec_result<CharT> FORMATXX_API parse_format_spec(basic_string_view<CharT> spec_string) noexcept;
     template <typename CharT> FORMATXX_PUBLIC basic_parse_spec_result<CharT> FORMATXX_API parse_printf_spec(basic_string_view<CharT> spec_string) noexcept;
@@ -126,15 +126,15 @@ template <typename CharT>
 class formatxx::basic_parse_spec_result {
 public:
     result_code code = result_code::success;
-    basic_format_spec<CharT> spec;
+    basic_format_options<CharT> options;
     basic_string_view<CharT> unparsed;
 };
 
 /// Extra formatting specifications.
 template <typename CharT>
-class formatxx::basic_format_spec {
+class formatxx::basic_format_options {
 public:
-    constexpr basic_format_spec() noexcept : has_precision(false), alternate_form(false), leading_zeroes(false) {}
+    constexpr basic_format_options() noexcept : has_precision(false), alternate_form(false), leading_zeroes(false) {}
 
     basic_string_view<CharT> user;
     unsigned width = 0;
@@ -149,10 +149,10 @@ public:
 
 namespace formatxx {
     /// Default format helpers.
-    FORMATXX_PUBLIC void FORMATXX_API format_value(format_writer& out, string_view str, format_spec const& spec = {}) noexcept;
-    FORMATXX_PUBLIC void FORMATXX_API format_value(format_writer& out, wstring_view str, format_spec const& spec = {}) noexcept;
-    FORMATXX_PUBLIC void FORMATXX_API format_value(wformat_writer& out, string_view str, wformat_spec const& spec = {}) noexcept;
-    FORMATXX_PUBLIC void FORMATXX_API format_value(wformat_writer& out, wstring_view str, wformat_spec const& spec = {}) noexcept;
+    FORMATXX_PUBLIC void FORMATXX_API format_value(format_writer& out, string_view str, format_options const& options = {}) noexcept;
+    FORMATXX_PUBLIC void FORMATXX_API format_value(format_writer& out, wstring_view str, format_options const& options = {}) noexcept;
+    FORMATXX_PUBLIC void FORMATXX_API format_value(wformat_writer& out, string_view str, wformat_options const& options = {}) noexcept;
+    FORMATXX_PUBLIC void FORMATXX_API format_value(wformat_writer& out, wstring_view str, wformat_options const& options = {}) noexcept;
 }
 
 /// @internal
@@ -165,13 +165,13 @@ namespace formatxx::_detail {
 
 extern template FORMATXX_PUBLIC formatxx::result_code FORMATXX_API formatxx::_detail::format_impl(basic_format_writer<char>& out, basic_string_view<char> format, basic_format_arg_list<char> args);
 extern template FORMATXX_PUBLIC formatxx::result_code FORMATXX_API formatxx::_detail::printf_impl(basic_format_writer<char>& out, basic_string_view<char> format, basic_format_arg_list<char> args);
-extern template FORMATXX_PUBLIC formatxx::result_code FORMATXX_API formatxx::_detail::basic_format_arg<char>::format_into(basic_format_writer<char>& output, basic_format_spec<char> const& spec) const;
+extern template FORMATXX_PUBLIC formatxx::result_code FORMATXX_API formatxx::_detail::basic_format_arg<char>::format_into(basic_format_writer<char>& output, basic_format_options<char> const& options) const;
 extern template FORMATXX_PUBLIC formatxx::basic_parse_spec_result<char> FORMATXX_API formatxx::parse_format_spec(basic_string_view<char> spec_string) noexcept;
 extern template FORMATXX_PUBLIC formatxx::basic_parse_spec_result<char> FORMATXX_API formatxx::parse_printf_spec(basic_string_view<char> spec_string) noexcept;
 
 extern template FORMATXX_PUBLIC formatxx::result_code FORMATXX_API formatxx::_detail::format_impl(basic_format_writer<wchar_t>& out, basic_string_view<wchar_t> format, basic_format_arg_list<wchar_t> args);
 extern template FORMATXX_PUBLIC formatxx::result_code FORMATXX_API formatxx::_detail::printf_impl(basic_format_writer<wchar_t>& out, basic_string_view<wchar_t> format, basic_format_arg_list<wchar_t> args);
-extern template FORMATXX_PUBLIC formatxx::result_code FORMATXX_API formatxx::_detail::basic_format_arg<wchar_t>::format_into(basic_format_writer<wchar_t>& output, basic_format_spec<wchar_t> const& spec) const;
+extern template FORMATXX_PUBLIC formatxx::result_code FORMATXX_API formatxx::_detail::basic_format_arg<wchar_t>::format_into(basic_format_writer<wchar_t>& output, basic_format_options<wchar_t> const& options) const;
 extern template FORMATXX_PUBLIC formatxx::basic_parse_spec_result<wchar_t> FORMATXX_API formatxx::parse_format_spec(basic_string_view<wchar_t> spec_string) noexcept;
 extern template FORMATXX_PUBLIC formatxx::basic_parse_spec_result<wchar_t> FORMATXX_API formatxx::parse_printf_spec(basic_string_view<wchar_t> spec_string) noexcept;
 
@@ -221,14 +221,14 @@ ResultT formatxx::printf_as(FormatT const& format, Args const& ... args) {
     return result;
 }
 
-/// Format a value into a buffer using the given spec.
+/// Format a value into a buffer using the given options.
 /// @param writer The write buffer that will receive the formatted text.
 /// @param value The value to format.
-/// @param spec The format control spec.
+/// @param options The format control options.
 /// @returns a result code indicating any errors.
 template <typename CharT, typename T>
-formatxx::result_code formatxx::format_value_to(basic_format_writer<CharT>& writer, T const& value, basic_format_spec<CharT> spec) {
-    return _detail::make_format_arg<CharT>(value).format_into(writer, spec);
+formatxx::result_code formatxx::format_value_to(basic_format_writer<CharT>& writer, T const& value, basic_format_options<CharT> const& options) {
+    return _detail::make_format_arg<CharT>(value).format_into(writer, options);
 }
 
 #endif // !defined(_guard_FORMATXX_H)

--- a/include/formatxx/format.h
+++ b/include/formatxx/format.h
@@ -84,8 +84,8 @@ namespace formatxx {
     template <typename CharT, typename T>
     result_code format_value_to(basic_format_writer<CharT>& writer, T const& value, basic_format_spec<CharT> spec = {});
 
-    template <typename CharT> FORMATXX_PUBLIC basic_parse_spec_result<CharT> FORMATXX_API parse_format_spec(basic_string_view<CharT> spec) noexcept;
-    template <typename CharT> FORMATXX_PUBLIC basic_parse_spec_result<CharT> FORMATXX_API parse_printf_spec(basic_string_view<CharT> spec) noexcept;
+    template <typename CharT> FORMATXX_PUBLIC basic_parse_spec_result<CharT> FORMATXX_API parse_format_spec(basic_string_view<CharT> spec_string) noexcept;
+    template <typename CharT> FORMATXX_PUBLIC basic_parse_spec_result<CharT> FORMATXX_API parse_printf_spec(basic_string_view<CharT> spec_string) noexcept;
 }
 
 enum class formatxx::result_code : unsigned int {
@@ -149,10 +149,10 @@ public:
 
 namespace formatxx {
     /// Default format helpers.
-    FORMATXX_PUBLIC void FORMATXX_API format_value(format_writer& out, string_view str, format_spec spec = {}) noexcept;
-    FORMATXX_PUBLIC void FORMATXX_API format_value(format_writer& out, wstring_view str, format_spec spec = {}) noexcept;
-    FORMATXX_PUBLIC void FORMATXX_API format_value(wformat_writer& out, string_view str, wformat_spec spec = {}) noexcept;
-    FORMATXX_PUBLIC void FORMATXX_API format_value(wformat_writer& out, wstring_view str, wformat_spec spec = {}) noexcept;
+    FORMATXX_PUBLIC void FORMATXX_API format_value(format_writer& out, string_view str, format_spec const& spec = {}) noexcept;
+    FORMATXX_PUBLIC void FORMATXX_API format_value(format_writer& out, wstring_view str, format_spec const& spec = {}) noexcept;
+    FORMATXX_PUBLIC void FORMATXX_API format_value(wformat_writer& out, string_view str, wformat_spec const& spec = {}) noexcept;
+    FORMATXX_PUBLIC void FORMATXX_API format_value(wformat_writer& out, wstring_view str, wformat_spec const& spec = {}) noexcept;
 }
 
 /// @internal
@@ -165,15 +165,15 @@ namespace formatxx::_detail {
 
 extern template FORMATXX_PUBLIC formatxx::result_code FORMATXX_API formatxx::_detail::format_impl(basic_format_writer<char>& out, basic_string_view<char> format, basic_format_arg_list<char> args);
 extern template FORMATXX_PUBLIC formatxx::result_code FORMATXX_API formatxx::_detail::printf_impl(basic_format_writer<char>& out, basic_string_view<char> format, basic_format_arg_list<char> args);
-extern template FORMATXX_PUBLIC formatxx::result_code FORMATXX_API formatxx::_detail::basic_format_arg<char>::format_into(basic_format_writer<char>& output, basic_format_spec<char> spec) const;
-extern template FORMATXX_PUBLIC formatxx::basic_parse_spec_result<char> FORMATXX_API formatxx::parse_format_spec(basic_string_view<char> spec) noexcept;
-extern template FORMATXX_PUBLIC formatxx::basic_parse_spec_result<char> FORMATXX_API formatxx::parse_printf_spec(basic_string_view<char> spec) noexcept;
+extern template FORMATXX_PUBLIC formatxx::result_code FORMATXX_API formatxx::_detail::basic_format_arg<char>::format_into(basic_format_writer<char>& output, basic_format_spec<char> const& spec) const;
+extern template FORMATXX_PUBLIC formatxx::basic_parse_spec_result<char> FORMATXX_API formatxx::parse_format_spec(basic_string_view<char> spec_string) noexcept;
+extern template FORMATXX_PUBLIC formatxx::basic_parse_spec_result<char> FORMATXX_API formatxx::parse_printf_spec(basic_string_view<char> spec_string) noexcept;
 
 extern template FORMATXX_PUBLIC formatxx::result_code FORMATXX_API formatxx::_detail::format_impl(basic_format_writer<wchar_t>& out, basic_string_view<wchar_t> format, basic_format_arg_list<wchar_t> args);
 extern template FORMATXX_PUBLIC formatxx::result_code FORMATXX_API formatxx::_detail::printf_impl(basic_format_writer<wchar_t>& out, basic_string_view<wchar_t> format, basic_format_arg_list<wchar_t> args);
-extern template FORMATXX_PUBLIC formatxx::result_code FORMATXX_API formatxx::_detail::basic_format_arg<wchar_t>::format_into(basic_format_writer<wchar_t>& output, basic_format_spec<wchar_t> spec) const;
-extern template FORMATXX_PUBLIC formatxx::basic_parse_spec_result<wchar_t> FORMATXX_API formatxx::parse_format_spec(basic_string_view<wchar_t> spec) noexcept;
-extern template FORMATXX_PUBLIC formatxx::basic_parse_spec_result<wchar_t> FORMATXX_API formatxx::parse_printf_spec(basic_string_view<wchar_t> spec) noexcept;
+extern template FORMATXX_PUBLIC formatxx::result_code FORMATXX_API formatxx::_detail::basic_format_arg<wchar_t>::format_into(basic_format_writer<wchar_t>& output, basic_format_spec<wchar_t> const& spec) const;
+extern template FORMATXX_PUBLIC formatxx::basic_parse_spec_result<wchar_t> FORMATXX_API formatxx::parse_format_spec(basic_string_view<wchar_t> spec_string) noexcept;
+extern template FORMATXX_PUBLIC formatxx::basic_parse_spec_result<wchar_t> FORMATXX_API formatxx::parse_printf_spec(basic_string_view<wchar_t> spec_string) noexcept;
 
 /// Write the string format using the given parameters into a buffer.
 /// @param writer The write buffer that will receive the formatted text.

--- a/include/formatxx/format.h
+++ b/include/formatxx/format.h
@@ -63,7 +63,9 @@ namespace formatxx {
     template <typename CharT> class basic_format_spec;
     template <typename CharT> class basic_parse_spec_result;
 
-    enum class result_code;
+    enum class result_code : unsigned int;
+    enum class justify : unsigned char;
+    enum class sign : unsigned char;
 
     using string_view = basic_string_view<char>;
     using format_writer = basic_format_writer<char>;
@@ -86,11 +88,23 @@ namespace formatxx {
     template <typename CharT> FORMATXX_PUBLIC basic_parse_spec_result<CharT> FORMATXX_API parse_printf_spec(basic_string_view<CharT> spec) noexcept;
 }
 
-enum class formatxx::result_code {
+enum class formatxx::result_code : unsigned int {
     success,
     out_of_range,
     malformed_input,
     out_of_space,
+};
+
+enum class formatxx::justify : unsigned char {
+    right,
+    left,
+    center
+};
+
+enum class formatxx::sign : unsigned char {
+    negative,
+    always,
+    space
 };
 
 #include "formatxx/_detail/append_writer.h"
@@ -120,16 +134,15 @@ public:
 template <typename CharT>
 class formatxx::basic_format_spec {
 public:
-    basic_format_spec() : has_precision(false), left_justify(false), prepend_sign(false), prepend_space(false), alternate_form(false), leading_zeroes(false) {}
+    basic_format_spec() : has_precision(false), alternate_form(false), leading_zeroes(false) {}
 
     basic_string_view<CharT> remaining;
     unsigned width = 0;
     unsigned precision = 0;
     CharT code = 0;
+    justify pad_justify = justify::right;
+    sign prepend_sign = sign::negative;
     bool has_precision : 1;
-    bool left_justify : 1;
-    bool prepend_sign : 1;
-    bool prepend_space : 1;
     bool alternate_form : 1;
     bool leading_zeroes : 1;
 };

--- a/include/formatxx/std_string.h
+++ b/include/formatxx/std_string.h
@@ -38,12 +38,12 @@
 
 namespace formatxx {
     template <typename CharT, typename StringCharT, typename TraitsT, typename AllocatorT>
-	void format_value(basic_format_writer<CharT>& out, std::basic_string<StringCharT, TraitsT, AllocatorT> const& string, basic_string_view<CharT> spec) {
+	void format_value(basic_format_writer<CharT>& out, std::basic_string<StringCharT, TraitsT, AllocatorT> const& string, basic_format_spec<CharT> spec) {
 		format_value(out, basic_string_view<StringCharT>(string.data(), string.size()), spec);
 	}
 
     template <typename CharT, typename StringCharT, typename TraitsT>
-    void format_value(basic_format_writer<CharT>& out, std::basic_string_view<StringCharT, TraitsT> const& string, basic_string_view<CharT> spec) {
+    void format_value(basic_format_writer<CharT>& out, std::basic_string_view<StringCharT, TraitsT> const& string, basic_format_spec<CharT> spec) {
         format_value(out, basic_string_view<StringCharT>(string.data(), string.size()), spec);
     }
 

--- a/include/formatxx/std_string.h
+++ b/include/formatxx/std_string.h
@@ -38,12 +38,12 @@
 
 namespace formatxx {
     template <typename CharT, typename StringCharT, typename TraitsT, typename AllocatorT>
-	void format_value(basic_format_writer<CharT>& out, std::basic_string<StringCharT, TraitsT, AllocatorT> const& string, basic_format_spec<CharT> spec) {
+	void format_value(basic_format_writer<CharT>& out, std::basic_string<StringCharT, TraitsT, AllocatorT> const& string, basic_format_spec<CharT> const& spec) {
 		format_value(out, basic_string_view<StringCharT>(string.data(), string.size()), spec);
 	}
 
     template <typename CharT, typename StringCharT, typename TraitsT>
-    void format_value(basic_format_writer<CharT>& out, std::basic_string_view<StringCharT, TraitsT> const& string, basic_format_spec<CharT> spec) {
+    void format_value(basic_format_writer<CharT>& out, std::basic_string_view<StringCharT, TraitsT> const& string, basic_format_spec<CharT> const& spec) {
         format_value(out, basic_string_view<StringCharT>(string.data(), string.size()), spec);
     }
 

--- a/include/formatxx/std_string.h
+++ b/include/formatxx/std_string.h
@@ -38,13 +38,13 @@
 
 namespace formatxx {
     template <typename CharT, typename StringCharT, typename TraitsT, typename AllocatorT>
-	void format_value(basic_format_writer<CharT>& out, std::basic_string<StringCharT, TraitsT, AllocatorT> const& string, basic_format_spec<CharT> const& spec) {
-		format_value(out, basic_string_view<StringCharT>(string.data(), string.size()), spec);
+	void format_value(basic_format_writer<CharT>& out, std::basic_string<StringCharT, TraitsT, AllocatorT> const& string, basic_format_options<CharT> const& options) {
+		format_value(out, basic_string_view<StringCharT>(string.data(), string.size()), options);
 	}
 
     template <typename CharT, typename StringCharT, typename TraitsT>
-    void format_value(basic_format_writer<CharT>& out, std::basic_string_view<StringCharT, TraitsT> const& string, basic_format_spec<CharT> const& spec) {
-        format_value(out, basic_string_view<StringCharT>(string.data(), string.size()), spec);
+    void format_value(basic_format_writer<CharT>& out, std::basic_string_view<StringCharT, TraitsT> const& string, basic_format_options<CharT> const& options) {
+        format_value(out, basic_string_view<StringCharT>(string.data(), string.size()), options);
     }
 
     template <typename StringT = std::string, typename FormatT, typename... Args> StringT format_string(FormatT const& format, Args const& ... args) {

--- a/source/format.cc
+++ b/source/format.cc
@@ -33,6 +33,7 @@
 #include <formatxx/_detail/format_arg_impl.h>
 #include <formatxx/_detail/format_impl.h>
 #include <formatxx/_detail/parse_format.h>
+#include <formatxx/_detail/parse_printf.h>
 #include <formatxx/_detail/printf_impl.h>
 #include <formatxx/_detail/write_string.h>
 
@@ -57,9 +58,11 @@ namespace formatxx {
 	template FORMATXX_PUBLIC result_code FORMATXX_API _detail::printf_impl(basic_format_writer<char>& out, basic_string_view<char> format, basic_format_arg_list<char> args);
     template FORMATXX_PUBLIC result_code FORMATXX_API _detail::basic_format_arg<char>::format_into(basic_format_writer<char>& output, basic_format_spec<char> spec) const;
 	template FORMATXX_PUBLIC basic_parse_spec_result<char> FORMATXX_API parse_format_spec(basic_string_view<char>) noexcept;
+    template FORMATXX_PUBLIC basic_parse_spec_result<char> FORMATXX_API parse_printf_spec(basic_string_view<char>) noexcept;
 
     template FORMATXX_PUBLIC result_code FORMATXX_API _detail::format_impl(basic_format_writer<wchar_t>& out, basic_string_view<wchar_t> format, basic_format_arg_list<wchar_t> args);
     template FORMATXX_PUBLIC result_code FORMATXX_API _detail::printf_impl(basic_format_writer<wchar_t>& out, basic_string_view<wchar_t> format, basic_format_arg_list<wchar_t> args);
     template FORMATXX_PUBLIC result_code FORMATXX_API _detail::basic_format_arg<wchar_t>::format_into(basic_format_writer<wchar_t>& output, basic_format_spec<wchar_t> spec) const;
     template FORMATXX_PUBLIC basic_parse_spec_result<wchar_t> FORMATXX_API parse_format_spec(basic_string_view<wchar_t>) noexcept;
+    template FORMATXX_PUBLIC basic_parse_spec_result<wchar_t> FORMATXX_API parse_printf_spec(basic_string_view<wchar_t>) noexcept;
 } // namespace formatxx

--- a/source/format.cc
+++ b/source/format.cc
@@ -37,30 +37,29 @@
 #include <formatxx/_detail/write_string.h>
 
 namespace formatxx {
-    FORMATXX_PUBLIC void FORMATXX_API format_value(format_writer& output, string_view value, string_view spec) noexcept {
+    FORMATXX_PUBLIC void FORMATXX_API format_value(format_writer& output, string_view value, format_spec spec) noexcept {
         _detail::write_string(output, value, spec);
     }
 
-    FORMATXX_PUBLIC void FORMATXX_API format_value(format_writer& output, wstring_view value, string_view spec) noexcept {
+    FORMATXX_PUBLIC void FORMATXX_API format_value(format_writer& output, wstring_view value, format_spec spec) noexcept {
         _detail::write_string(output, value, spec);
     }
 
-    FORMATXX_PUBLIC void FORMATXX_API format_value(wformat_writer& output, string_view value, wstring_view spec) noexcept {
+    FORMATXX_PUBLIC void FORMATXX_API format_value(wformat_writer& output, string_view value, wformat_spec spec) noexcept {
         _detail::write_string(output, value, spec);
     }
 
-    FORMATXX_PUBLIC void FORMATXX_API format_value(wformat_writer& output, wstring_view value, wstring_view spec) noexcept {
+    FORMATXX_PUBLIC void FORMATXX_API format_value(wformat_writer& output, wstring_view value, wformat_spec spec) noexcept {
         _detail::write_string(output, value, spec);
     }
 
 	template FORMATXX_PUBLIC result_code FORMATXX_API _detail::format_impl(basic_format_writer<char>& out, basic_string_view<char> format, basic_format_arg_list<char> args);
 	template FORMATXX_PUBLIC result_code FORMATXX_API _detail::printf_impl(basic_format_writer<char>& out, basic_string_view<char> format, basic_format_arg_list<char> args);
-    template FORMATXX_PUBLIC result_code FORMATXX_API _detail::basic_format_arg<char>::format_into(basic_format_writer<char>& output, basic_string_view<char> spec) const;
-	template FORMATXX_PUBLIC basic_format_spec<char> FORMATXX_API parse_format_spec(basic_string_view<char>) noexcept;
-
+    template FORMATXX_PUBLIC result_code FORMATXX_API _detail::basic_format_arg<char>::format_into(basic_format_writer<char>& output, basic_format_spec<char> spec) const;
+	template FORMATXX_PUBLIC basic_parse_spec_result<char> FORMATXX_API parse_format_spec(basic_string_view<char>) noexcept;
 
     template FORMATXX_PUBLIC result_code FORMATXX_API _detail::format_impl(basic_format_writer<wchar_t>& out, basic_string_view<wchar_t> format, basic_format_arg_list<wchar_t> args);
     template FORMATXX_PUBLIC result_code FORMATXX_API _detail::printf_impl(basic_format_writer<wchar_t>& out, basic_string_view<wchar_t> format, basic_format_arg_list<wchar_t> args);
-    template FORMATXX_PUBLIC result_code FORMATXX_API _detail::basic_format_arg<wchar_t>::format_into(basic_format_writer<wchar_t>& output, basic_string_view<wchar_t> spec) const;
-    template FORMATXX_PUBLIC basic_format_spec<wchar_t> FORMATXX_API parse_format_spec(basic_string_view<wchar_t>) noexcept;
+    template FORMATXX_PUBLIC result_code FORMATXX_API _detail::basic_format_arg<wchar_t>::format_into(basic_format_writer<wchar_t>& output, basic_format_spec<wchar_t> spec) const;
+    template FORMATXX_PUBLIC basic_parse_spec_result<wchar_t> FORMATXX_API parse_format_spec(basic_string_view<wchar_t>) noexcept;
 } // namespace formatxx

--- a/source/format.cc
+++ b/source/format.cc
@@ -38,31 +38,31 @@
 #include <formatxx/_detail/write_string.h>
 
 namespace formatxx {
-    FORMATXX_PUBLIC void FORMATXX_API format_value(format_writer& output, string_view value, format_spec spec) noexcept {
+    FORMATXX_PUBLIC void FORMATXX_API format_value(format_writer& output, string_view value, format_spec const& spec) noexcept {
         _detail::write_string(output, value, spec);
     }
 
-    FORMATXX_PUBLIC void FORMATXX_API format_value(format_writer& output, wstring_view value, format_spec spec) noexcept {
+    FORMATXX_PUBLIC void FORMATXX_API format_value(format_writer& output, wstring_view value, format_spec const& spec) noexcept {
         _detail::write_string(output, value, spec);
     }
 
-    FORMATXX_PUBLIC void FORMATXX_API format_value(wformat_writer& output, string_view value, wformat_spec spec) noexcept {
+    FORMATXX_PUBLIC void FORMATXX_API format_value(wformat_writer& output, string_view value, wformat_spec const& spec) noexcept {
         _detail::write_string(output, value, spec);
     }
 
-    FORMATXX_PUBLIC void FORMATXX_API format_value(wformat_writer& output, wstring_view value, wformat_spec spec) noexcept {
+    FORMATXX_PUBLIC void FORMATXX_API format_value(wformat_writer& output, wstring_view value, wformat_spec const& spec) noexcept {
         _detail::write_string(output, value, spec);
     }
 
 	template FORMATXX_PUBLIC result_code FORMATXX_API _detail::format_impl(basic_format_writer<char>& out, basic_string_view<char> format, basic_format_arg_list<char> args);
 	template FORMATXX_PUBLIC result_code FORMATXX_API _detail::printf_impl(basic_format_writer<char>& out, basic_string_view<char> format, basic_format_arg_list<char> args);
-    template FORMATXX_PUBLIC result_code FORMATXX_API _detail::basic_format_arg<char>::format_into(basic_format_writer<char>& output, basic_format_spec<char> spec) const;
-	template FORMATXX_PUBLIC basic_parse_spec_result<char> FORMATXX_API parse_format_spec(basic_string_view<char>) noexcept;
-    template FORMATXX_PUBLIC basic_parse_spec_result<char> FORMATXX_API parse_printf_spec(basic_string_view<char>) noexcept;
+    template FORMATXX_PUBLIC result_code FORMATXX_API _detail::basic_format_arg<char>::format_into(basic_format_writer<char>& output, basic_format_spec<char> const& spec) const;
+	template FORMATXX_PUBLIC basic_parse_spec_result<char> FORMATXX_API parse_format_spec(basic_string_view<char> spec_string) noexcept;
+    template FORMATXX_PUBLIC basic_parse_spec_result<char> FORMATXX_API parse_printf_spec(basic_string_view<char> spec_string) noexcept;
 
     template FORMATXX_PUBLIC result_code FORMATXX_API _detail::format_impl(basic_format_writer<wchar_t>& out, basic_string_view<wchar_t> format, basic_format_arg_list<wchar_t> args);
     template FORMATXX_PUBLIC result_code FORMATXX_API _detail::printf_impl(basic_format_writer<wchar_t>& out, basic_string_view<wchar_t> format, basic_format_arg_list<wchar_t> args);
-    template FORMATXX_PUBLIC result_code FORMATXX_API _detail::basic_format_arg<wchar_t>::format_into(basic_format_writer<wchar_t>& output, basic_format_spec<wchar_t> spec) const;
-    template FORMATXX_PUBLIC basic_parse_spec_result<wchar_t> FORMATXX_API parse_format_spec(basic_string_view<wchar_t>) noexcept;
-    template FORMATXX_PUBLIC basic_parse_spec_result<wchar_t> FORMATXX_API parse_printf_spec(basic_string_view<wchar_t>) noexcept;
+    template FORMATXX_PUBLIC result_code FORMATXX_API _detail::basic_format_arg<wchar_t>::format_into(basic_format_writer<wchar_t>& output, basic_format_spec<wchar_t> const& spec) const;
+    template FORMATXX_PUBLIC basic_parse_spec_result<wchar_t> FORMATXX_API parse_format_spec(basic_string_view<wchar_t> spec_string) noexcept;
+    template FORMATXX_PUBLIC basic_parse_spec_result<wchar_t> FORMATXX_API parse_printf_spec(basic_string_view<wchar_t> spec_string) noexcept;
 } // namespace formatxx

--- a/source/format.cc
+++ b/source/format.cc
@@ -38,31 +38,31 @@
 #include <formatxx/_detail/write_string.h>
 
 namespace formatxx {
-    FORMATXX_PUBLIC void FORMATXX_API format_value(format_writer& output, string_view value, format_spec const& spec) noexcept {
-        _detail::write_string(output, value, spec);
+    FORMATXX_PUBLIC void FORMATXX_API format_value(format_writer& output, string_view value, format_options const& options) noexcept {
+        _detail::write_string(output, value, options);
     }
 
-    FORMATXX_PUBLIC void FORMATXX_API format_value(format_writer& output, wstring_view value, format_spec const& spec) noexcept {
-        _detail::write_string(output, value, spec);
+    FORMATXX_PUBLIC void FORMATXX_API format_value(format_writer& output, wstring_view value, format_options const& options) noexcept {
+        _detail::write_string(output, value, options);
     }
 
-    FORMATXX_PUBLIC void FORMATXX_API format_value(wformat_writer& output, string_view value, wformat_spec const& spec) noexcept {
-        _detail::write_string(output, value, spec);
+    FORMATXX_PUBLIC void FORMATXX_API format_value(wformat_writer& output, string_view value, wformat_options const& options) noexcept {
+        _detail::write_string(output, value, options);
     }
 
-    FORMATXX_PUBLIC void FORMATXX_API format_value(wformat_writer& output, wstring_view value, wformat_spec const& spec) noexcept {
-        _detail::write_string(output, value, spec);
+    FORMATXX_PUBLIC void FORMATXX_API format_value(wformat_writer& output, wstring_view value, wformat_options const& options) noexcept {
+        _detail::write_string(output, value, options);
     }
 
 	template FORMATXX_PUBLIC result_code FORMATXX_API _detail::format_impl(basic_format_writer<char>& out, basic_string_view<char> format, basic_format_arg_list<char> args);
 	template FORMATXX_PUBLIC result_code FORMATXX_API _detail::printf_impl(basic_format_writer<char>& out, basic_string_view<char> format, basic_format_arg_list<char> args);
-    template FORMATXX_PUBLIC result_code FORMATXX_API _detail::basic_format_arg<char>::format_into(basic_format_writer<char>& output, basic_format_spec<char> const& spec) const;
+    template FORMATXX_PUBLIC result_code FORMATXX_API _detail::basic_format_arg<char>::format_into(basic_format_writer<char>& output, basic_format_options<char> const& options) const;
 	template FORMATXX_PUBLIC basic_parse_spec_result<char> FORMATXX_API parse_format_spec(basic_string_view<char> spec_string) noexcept;
     template FORMATXX_PUBLIC basic_parse_spec_result<char> FORMATXX_API parse_printf_spec(basic_string_view<char> spec_string) noexcept;
 
     template FORMATXX_PUBLIC result_code FORMATXX_API _detail::format_impl(basic_format_writer<wchar_t>& out, basic_string_view<wchar_t> format, basic_format_arg_list<wchar_t> args);
     template FORMATXX_PUBLIC result_code FORMATXX_API _detail::printf_impl(basic_format_writer<wchar_t>& out, basic_string_view<wchar_t> format, basic_format_arg_list<wchar_t> args);
-    template FORMATXX_PUBLIC result_code FORMATXX_API _detail::basic_format_arg<wchar_t>::format_into(basic_format_writer<wchar_t>& output, basic_format_spec<wchar_t> const& spec) const;
+    template FORMATXX_PUBLIC result_code FORMATXX_API _detail::basic_format_arg<wchar_t>::format_into(basic_format_writer<wchar_t>& output, basic_format_options<wchar_t> const& options) const;
     template FORMATXX_PUBLIC basic_parse_spec_result<wchar_t> FORMATXX_API parse_format_spec(basic_string_view<wchar_t> spec_string) noexcept;
     template FORMATXX_PUBLIC basic_parse_spec_result<wchar_t> FORMATXX_API parse_printf_spec(basic_string_view<wchar_t> spec_string) noexcept;
 } // namespace formatxx

--- a/tests/test_format.cc
+++ b/tests/test_format.cc
@@ -10,18 +10,18 @@ enum class custom_enum { foo, bar };
 
 class custom_type {};
 
-void format_value(formatxx::format_writer& writer, custom_enum value, formatxx::format_spec spec) noexcept {
+void format_value(formatxx::format_writer& writer, custom_enum value, formatxx::format_options options) noexcept {
     switch (value) {
-    case custom_enum::foo: format_value_to(writer, "foo", spec); return;
-    case custom_enum::bar: format_value_to(writer, "bar", spec); return;
+    case custom_enum::foo: format_value_to(writer, "foo", options); return;
+    case custom_enum::bar: format_value_to(writer, "bar", options); return;
     }
 }
 
-void format_value(formatxx::format_writer& writer, custom_type, formatxx::format_spec spec) noexcept {
-    format_value_to(writer, "custom", spec);
+void format_value(formatxx::format_writer& writer, custom_type, formatxx::format_options options) noexcept {
+    format_value_to(writer, "custom", options);
 }
-void format_value(formatxx::format_writer& writer, custom_type const*, formatxx::format_spec spec) noexcept {
-    format_value_to(writer, "custom pointer", spec);
+void format_value(formatxx::format_writer& writer, custom_type const*, formatxx::format_options options) noexcept {
+    format_value_to(writer, "custom pointer", options);
 }
 
 template <typename T>

--- a/tests/test_format.cc
+++ b/tests/test_format.cc
@@ -10,18 +10,18 @@ enum class custom_enum { foo, bar };
 
 class custom_type {};
 
-void format_value(formatxx::format_writer& writer, custom_enum value, formatxx::string_view spec) noexcept {
+void format_value(formatxx::format_writer& writer, custom_enum value, formatxx::format_spec spec) noexcept {
     switch (value) {
-    case custom_enum::foo: writer.write("foo"); return;
-    case custom_enum::bar: writer.write("bar"); return;
+    case custom_enum::foo: format_value_to(writer, "foo", spec); return;
+    case custom_enum::bar: format_value_to(writer, "bar", spec); return;
     }
 }
 
-void format_value(formatxx::format_writer& writer, custom_type, formatxx::string_view spec) noexcept {
-    writer.write("custom");
+void format_value(formatxx::format_writer& writer, custom_type, formatxx::format_spec spec) noexcept {
+    format_value_to(writer, "custom", spec);
 }
-void format_value(formatxx::format_writer& writer, custom_type const*, formatxx::string_view spec) noexcept {
-    writer.write("custom pointer");
+void format_value(formatxx::format_writer& writer, custom_type const*, formatxx::format_spec spec) noexcept {
+    format_value_to(writer, "custom pointer", spec);
 }
 
 template <typename T>


### PR DESCRIPTION
Changes the interface for `format_value` to take a `basic_format_spec` instead of a `basic_string_view` as its spec argument.